### PR TITLE
The stripe has no inline shadow and it's smaller

### DIFF
--- a/source/assets/stylesheets/components/_pop-stripe.scss.erb
+++ b/source/assets/stylesheets/components/_pop-stripe.scss.erb
@@ -15,7 +15,6 @@ $colors: <% data.color.colors.each do |swatch| %>$<%= swatch.name %> <% end %>;
 }
 
 .pop-stripe {
-  height: .5em;
+  height: .22em;
   @include background-image(stripes(left, ($colors)));
-  @include box-shadow(0 -1px 2px rgba(#000, .25) inset);
 }


### PR DESCRIPTION
The reasoning behind removing the inline shadow is that it's uneeded.
It's a distraction, and the overall theme wants to go the flat route.

The reasoning behind making the stripe smaller, is that when it's too
tall it's distracting, also 0.5 em seems to be a bit too much, especially
when compared against the logo thicker part ( 8px ). I've lowered it to half
of that 0.22em ~= 4px.

![](https://dl.dropboxusercontent.com/s/5va652b1tr4cq7z/2013-10-13%20at%205.25%20PM.png)
