### PR TITLE
Margin links for header and footer!

### DIFF
--- a/source/assets/stylesheets/regions/_banner.scss
+++ b/source/assets/stylesheets/regions/_banner.scss
@@ -11,6 +11,13 @@
   }
 }
 
+footer, .banner {
+  @include breakpoint($tablet-large) {
+    margin-left: 40px;
+    margin-right: 40px;
+  }
+}
+
 .site-brand {
   @include font-size-regular;
   margin: 0;

--- a/source/layouts/regions/_contentinfo.haml
+++ b/source/layouts/regions/_contentinfo.haml
@@ -4,8 +4,8 @@
       %ul
         %li.contentinfo-legal
           :markdown
-            Sass &copy; 2006&ndash;2013 [Hampton Catlin](http://www.hamptoncatlin.com/),
-            [Nathan Weizenbaum](http://nex-3.com/),
+            Sass &copy; 2006&ndash;2013 [Hampton Catlin](#),
+            [Nathan Weizenbaum](#),
             [Chris&nbsp;Eppstein](http://chriseppstein.github.io/),
             and&nbsp;numerous&nbsp;contributors.
 


### PR DESCRIPTION
Here's what I've used. Seems to look right, but there's probably a cleaner way to do it using your existing styles. 40px seems about right. I don't know why 37daec0 is showing up in this pull request.
