### PR TITLE
Fix typo

### DIFF
--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -35,7 +35,7 @@ layout: layout_1_column
       %h3 Industry Approved
       %p
         Over and over again, the industry is choosing Sass as the premier CSS
-        extension languages. It's so true that we feel a little bad for
+        extension language. It's so true that we feel a little bad for
         the&nbsp;upstarts.
     %li
       %h3 Large Community


### PR DESCRIPTION
Fix a typo on the new sass-lang.com index page. (Changing "extension languages" to "extension language" under "Industry Approved")
