### PR TITLE
border-color should just be a color, not style and size as well

### DIFF
--- a/source/code-snippets/_homepage-extend-scss.md
+++ b/source/code-snippets/_homepage-extend-scss.md
@@ -1,6 +1,6 @@
 ```scss
 .message {
-  border-color: 1px solid #ccc;
+  border: 1px solid #ccc;
   padding: 10px;
   color: #333;
 }


### PR DESCRIPTION
You can't use border-color like that, can you? Border color should just be a color.
