### PR TITLE
Fix typo in code snippet for extend

### DIFF
--- a/source/code-snippets/_homepage-extend-css.md
+++ b/source/code-snippets/_homepage-extend-css.md
@@ -1,6 +1,6 @@
 ```css
 .message, .success, .error, .warning {
-  border-color: 1px solid #cccccc;
+  border: 1px solid #cccccc;
   padding: 10px;
   color: #333;
 }


### PR DESCRIPTION
The SCSS snippet sets the "border" property of .message, but the CSS snippet has "border-color" (should be "border"). (And obviously you can't use "1px solid" on "border-color".)
