### PR TITLE
Fix jump in navigation toggle animation

### DIFF
--- a/source/assets/css/regions/_navigation.scss
+++ b/source/assets/css/regions/_navigation.scss
@@ -1,5 +1,7 @@
 .navigation {
-  @include padding-leader;
+  ul {
+    @include padding-leader;
+  }
 
   li {
     @include trailer(.5);


### PR DESCRIPTION
By moving the `padding` from `.navigation`, the element being animated, to an interior element, we can avoid the jump at the end of the navigation toggle.

Screencast comparing navs: http://f.cl.ly/items/463t401X0n3K1X2D1O1o/Screeny%20Video%20Nov%2029,%202013,%202.13.20%20AM.iphone.mp4
