### PR TITLE
removes non-existing -o- Opera prefix

### DIFF
--- a/source/code-snippets/_homepage-mixins-scss.md
+++ b/source/code-snippets/_homepage-mixins-scss.md
@@ -3,7 +3,6 @@
   -webkit-border-radius: $radius;
      -moz-border-radius: $radius;
       -ms-border-radius: $radius;
-       -o-border-radius: $radius;
           border-radius: $radius;
 }
 


### PR DESCRIPTION
Opera never prefixed border-radius

Update: 

Microsoft never had -ms-border-radius either so that'd need removing also.
