### PR TITLE
removes non-existing -o- Opera prefix

### DIFF
--- a/source/code-snippets/_homepage-mixins-css.md
+++ b/source/code-snippets/_homepage-mixins-css.md
@@ -3,7 +3,6 @@
   -webkit-border-radius: 10px;
   -moz-border-radius: 10px;
   -ms-border-radius: 10px;
-  -o-border-radius: 10px;
   border-radius: 10px;
 }
 ```


### PR DESCRIPTION
Opera never prefixed border-radius.

Update: 

Microsoft never had -ms-border-radius either so that'd need removing also.
