### PR TITLE
Remove dead link to Prepros Pro

### DIFF
--- a/source/install.html.haml
+++ b/source/install.html.haml
@@ -47,12 +47,7 @@ layout: layout_1_column
         %span.windows-icon
       %li
         = link_to "Prepros", "http://alphapixels.com/prepros/"
-        %span.info (Open Source)
-        %span.mac-icon
-        %span.windows-icon
-      %li
-        = link_to "Prepros Pro", "http://alphapixels.com/prepros/pro"
-        %span.info (Paid)
+        %span.info (Paid, Open Source)
         %span.mac-icon
         %span.windows-icon
       %li


### PR DESCRIPTION
http://alphapixels.com/prepros/pro is a dead link and http://alphapixels.com/prepros/ now provides information for the OSS and Paid versions. I consolidated both entries.

If I missed any important requirements for a pull request please let me know.
