### PR TITLE
Escape underscores in file names on import example

### DIFF
--- a/source/guide.html.haml
+++ b/source/guide.html.haml
@@ -75,7 +75,7 @@ title: Sass Basics
 
       CSS has an import option that lets you split your CSS into smaller, more maintainable portions. The only drawback is that each time you use <code>@import</code> in CSS it creates another HTTP request. Sass builds on top of the current CSS <code>@import</code> but instead of requiring an HTTP request, Sass will take the file that you want to import and combine it with the file you're importing into so you can serve a single CSS file to the web browser.
 
-      Let's say you have a couple of Sass files, <code>_reset.scss</code> and <code>base.scss</code>. We want to import <code>_reset.scss</code> into <code>base.scss</code>.
+      Let's say you have a couple of Sass files, <code>\_reset.scss</code> and <code>base.scss</code>. We want to import <code>\_reset.scss</code> into <code>base.scss</code>.
 
     ~ partial "code-snippets/homepage-import-1-scss"
     ~ partial "code-snippets/homepage-import-2-scss"


### PR DESCRIPTION
Right now, the filename shows in italic sans underscore because Markdown is parsing it.
