### PR TITLE
Fix documentation description of partials

### DIFF
--- a/source/guide.html.haml
+++ b/source/guide.html.haml
@@ -85,7 +85,7 @@ title: Sass Basics
     :markdown
       ## Partials
 
-      You can create partial Sass files that contain little snippets of CSS that you can include in other Sass files. This is a great way to modularize your CSS and help keep things easier to maintain. A partial is simply a Sass file named with a leading underscore. You might name it something like <code>_partial.scss</code>. The underscore lets Sass know that the file is only a partial file and that it should be generated into a CSS file. Sass partials are used with the <code>@import</code> directive.
+      You can create partial Sass files that contain little snippets of CSS that you can include in other Sass files. This is a great way to modularize your CSS and help keep things easier to maintain. A partial is simply a Sass file named with a leading underscore. You might name it something like <code>_partial.scss</code>. The underscore lets Sass know that the file is only a partial file and that it should not be generated into a CSS file. Sass partials are used with the <code>@import</code> directive.
 
       ***
 


### PR DESCRIPTION
Files that begin with an underscore should not be generated into a stand alone CSS file.
