### PR TITLE
Adding a 'Come to CampSass' alert on the homepage

### DIFF
--- a/source/assets/css/components/_alerts.scss
+++ b/source/assets/css/components/_alerts.scss
@@ -31,3 +31,15 @@
 }
 
 .release-name { white-space: nowrap; }
+
+// CAMP SASS //
+
+.alert.campsass {
+  background: $iron;
+  color: $color-text-heading;
+  a {
+    color: $color-text-link;
+  }
+}
+
+// END CAMP SASS //

--- a/source/layouts/layout.haml
+++ b/source/layouts/layout.haml
@@ -26,7 +26,10 @@
         - if content_for?(:section_middle)
           %section.section-middle
             .container= yield_content :section_middle
-
+      // CAMP SASS //
+      .alert.campsass
+        Registration is now open for #{link_to "Camp Sass", "http://campsass.com", :target=>"_blank"}, held in San Francisco on Aril 19th.
+      // END CAMP SASS//
       .alert.release
         .container
           %ul


### PR DESCRIPTION
In two files, adding a small banner above the "Current release" with a (tasteful) ad for Camp Sass.
![screen shot 2014-03-20 at 11 03 46am](https://f.cloud.github.com/assets/108884/2475667/036d9a50-b05a-11e3-95e8-59095f41a979.png)
