### PR TITLE
Removing the CampSass alert

### DIFF
--- a/source/layouts/layout.haml
+++ b/source/layouts/layout.haml
@@ -26,10 +26,6 @@
         - if content_for?(:section_middle)
           %section.section-middle
             .container= yield_content :section_middle
-      // CAMP SASS //
-      .alert.campsass
-        Registration is now open for #{link_to "Camp Sass", "http://campsass.com", :target=>"_blank"}, held in San Francisco on April 19th.
-      // END CAMP SASS//
       .alert.release
         .container
           %ul


### PR DESCRIPTION
As CampSass is over (well, almost), we can remove the CampSass alert from the sass-lang site.
