### PR TITLE
Add missing period.

### DIFF
--- a/source/guide.html.haml
+++ b/source/guide.html.haml
@@ -113,7 +113,7 @@ title: Sass Basics
 
     :markdown
 
-      Notice we're using <code>@import 'reset';</code> in the <code>base.scss</code> file. When you import a file you don't need to include the file extension <code>.scss</code> Sass is smart and will figure it out for you. When you generate the CSS you'll&nbsp;get:
+      Notice we're using <code>@import 'reset';</code> in the <code>base.scss</code> file. When you import a file you don't need to include the file extension <code>.scss</code>. Sass is smart and will figure it out for you. When you generate the CSS you'll&nbsp;get:
 
     ~ partial "code-snippets/homepage-import-css"
 


### PR DESCRIPTION
The "Import" section of the "Sass Basics" page was missing a period in the following sentence:

"When you import a file you don't need to include the file extension <code>.scss</code>"

It should read:

"When you import a file you don't need to include the file extension <code>.scss</code>."
