### PR TITLE
Fix wrapping of "COMMAND LINE" in chrome.

### DIFF
--- a/source/assets/css/foundation/_headings.scss
+++ b/source/assets/css/foundation/_headings.scss
@@ -47,4 +47,5 @@ h3 { font-family: $font-family-display; }
   text-transform: uppercase;
   letter-spacing: .03125em;
   color: $color-text-weak;
+  white-space: nowrap;
 }


### PR DESCRIPTION
The text "COMMAND LINE" on the Install page is wrapping in chrome. No wrap is occurring in Firefox or IE.

The problem:

![sass install sass](https://cloud.githubusercontent.com/assets/2624149/2933231/277766fe-d7bc-11e3-8158-f0e3a47bec06.png)

Adding a white-space: nowrap; rule fixes the issue:

![sass install sass 1](https://cloud.githubusercontent.com/assets/2624149/2933254/53c56166-d7bc-11e3-95b5-c621fd99f099.png)
