### PR TITLE
Update sass repository URL

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,7 @@ end
 
 task :sass do
   unless Dir.exists?(".sass")
-    sh %{git clone git://github.com/nex3/sass .sass}
+    sh %{git clone git://github.com/sass/sass .sass}
   end
 
   Dir.chdir(".sass") do

--- a/source/community.html.haml
+++ b/source/community.html.haml
@@ -50,22 +50,22 @@ layout: layout_1_column
   %p When adding bug reports, feature requests, or code there are a couple of primary branches we use.
 
   %dl
-    %dt= link_to "Stable", "https://github.com/nex3/sass"
+    %dt= link_to "Stable", "https://github.com/sass/sass"
     %dd
       The stable branch is where we do development on the released version.
       The majority of bug fixes should go here.
-      If you're just reporting a bug <a href="https://github.com/nex3/sass/issues">add an issue</a> and
+      If you're just reporting a bug <a href="https://github.com/sass/sass/issues">add an issue</a> and
       note the version of Sass where you experienced the issue in your comment.
       If you have some code to contribute, fork the stable branch and send us a pull request.
       We'll review your patch and either accept or decline with comments.
       All bug fixes must be thoroughly tested and the tests must pass
-      the <a href="https://travis-ci.org/nex3/sass/builds">build</a> on all supported versions of ruby.
+      the <a href="https://travis-ci.org/sass/sass/builds">build</a> on all supported versions of ruby.
 
   %dl
-    %dt= link_to "Master", "https://github.com/nex3/sass/tree/master"
+    %dt= link_to "Master", "https://github.com/sass/sass/tree/master"
     %dd
       The master branch is where we keep track of the next version of Sass.
-      New feature requests should be made on the <a href="https://github.com/nex3/sass/issues">issue tracker</a>
+      New feature requests should be made on the <a href="https://github.com/sass/sass/issues">issue tracker</a>
       and discussed with the <a href="http://github.com/nex3">core</a> <a href="http://github.com/chriseppstein">team</a>
       before implementation begins to avoid wasted effort.
       Pull requests for new features should be made against the master branch.
@@ -82,7 +82,7 @@ layout: layout_1_column
     %li If your change is user-facing, update the appropriate section in reference documentation.
     %li Don't combine several features or bug fixes into the same pull request.
     %li All code is given a thorough review and will likely require several iterations before being accepted.
-    %li All code changes must be thoroughly tested and the tests must pass the <a href="https://travis-ci.org/nex3/sass/builds">build</a> on all supported versions of ruby.
+    %li All code changes must be thoroughly tested and the tests must pass the <a href="https://travis-ci.org/sass/sass/builds">build</a> on all supported versions of ruby.
 
 
 

--- a/source/layouts/layout.haml
+++ b/source/layouts/layout.haml
@@ -34,7 +34,7 @@
             - else
               %li Current Release: <span class="release-name">???</span>
             %li=link_to "Release Notes", "/documentation/file.SASS_CHANGELOG.html"
-            %li=link_to "Fork on Github", "https://github.com/nex3/sass"
+            %li=link_to "Fork on Github", "https://github.com/sass/sass"
 
       - if content_for?(:section_bottom)
         %section.section-bottom


### PR DESCRIPTION
Hello.
These links look outdated.
For example, the link of travis page is not found.
Thanks.
