### PR TITLE
Fix RubyInstaller link

### DIFF
--- a/source/install.html.haml
+++ b/source/install.html.haml
@@ -69,7 +69,7 @@ title: Install Sass
       %dd
         Before you start using Sass you will need to install Ruby. The fastest
         way to get Ruby on your Windows computer is to use
-        <a href="http://www.rubyinstaller.org">Ruby Installer</a>. It's a
+        <a href="http://rubyinstaller.org">Ruby Installer</a>. It's a
         single-click installer that will get everything set up for you super
         fast.
 


### PR DESCRIPTION
The www. subdomain no longer goes to the correct site. It's just rubyinstaller.org now.
