### PR TITLE
Update Prepros item on install page for new version 5

### DIFF
--- a/source/install.html.haml
+++ b/source/install.html.haml
@@ -45,10 +45,11 @@ title: Install Sass
         %span.mac-icon
         %span.windows-icon
       %li
-        = link_to "Prepros", "http://alphapixels.com/prepros/"
-        %span.info (Paid, Open Source)
+        = link_to "Prepros", "https://prepros.io/"
+        %span.info (Paid)
         %span.mac-icon
         %span.windows-icon
+        %span.linux-icon
       %li
         = link_to "Scout", "http://mhs.github.io/scout-app/"
         %span.info (Open Source)


### PR DESCRIPTION
Prepros has a new website (https://prepros.io/) and it is now also available for Linux.

Also, v5 isn't open source anymore, though v4 will remain open source (source: https://github.com/Subash/Prepros/issues/663#issuecomment-57082986). Deleted 'Open Source' in description because there is no mention of the repository on the Prepros website so new users are unlikely to encounter it.

I was not entirely sure about this one so I didn't include it, but should the Sass website include a mention that there is a free version of Prepros available?
