### PR TITLE
fix links to documentation from styleguide pages

### DIFF
--- a/source/layouts/styleguide.haml
+++ b/source/layouts/styleguide.haml
@@ -53,7 +53,7 @@
                       - unless page.url =~ /assets/
                         - unless page.data.title == "Style Guide"
                           - unless page.data.title == "Responsive Test"
-                            %li= link_to "#{page.data.title}", "#{root_url}#{page.url}"
+                            %li= link_to "#{page.data.title}", "#{root_url}#{page.url.gsub!(/(\/)+$/,'')}"
 
 
             - if content_for?(:complementary)


### PR DESCRIPTION
The trailing slash on URLs like http://sass-lang.com/styleguide/code/ caused the link to Documentation to break. This removes the trailing slash from generated URLs. P.S. First real commit; be gentle!
