### PR TITLE
Fix libSass link in community page

### DIFF
--- a/data/community.yml
+++ b/data/community.yml
@@ -42,7 +42,7 @@ blogs:
 
 projects:
   - name: "libSass"
-    url: "/libSass"
+    url: "/libsass"
     description: "a CSS (and Sass!) authoring framework"
   - name: "Compass"
     url: "http://compass-style.org/"


### PR DESCRIPTION
CamelCased `libSass` produce a 404.
