### PR TITLE
Reflect Mixture.io changes on the install page

### DIFF
--- a/source/install.html.haml
+++ b/source/install.html.haml
@@ -41,7 +41,7 @@ title: Install Sass
         %span.windows-icon
       %li
         = link_to "Mixture", "http://mixture.io/"
-        %span.info (Paid)
+        %span.info (Free)
         %span.mac-icon
         %span.windows-icon
       %li


### PR DESCRIPTION
Mixture.io is no longer under active development and now a free
application for OS X and Windows.

Details: http://mixture.io/blog/free/
