### PR TITLE
Changing the date to 2015

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2006-2014 Hampton Catlin, Natalie Weizenbaum, and Chris Eppstein, Jina
+Copyright (c) 2006-2015 Hampton Catlin, Natalie Weizenbaum, and Chris Eppstein, Jina
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/source/layouts/regions/_contentinfo.haml
+++ b/source/layouts/regions/_contentinfo.haml
@@ -4,7 +4,7 @@
       %ul
         %li.contentinfo-legal
           :markdown
-            Sass &copy; 2006&ndash;2014 [Hampton Catlin](http://www.hamptoncatlin.com/),
+            Sass &copy; 2006&ndash;2015 [Hampton Catlin](http://www.hamptoncatlin.com/),
             [Natalie Weizenbaum](http://nex-3.com/),
             [Chris&nbsp;Eppstein](http://chriseppstein.github.io/),
             and&nbsp;numerous&nbsp;contributors.


### PR DESCRIPTION
The dates on the site were copyrighted between 2006-2014. This is just a silly PR to update it to 2015.