### PR TITLE
Add Omniref instant documentation navigation.

### DIFF
--- a/source/layouts/head/_js.haml
+++ b/source/layouts/head/_js.haml
@@ -1,5 +1,7 @@
 = javascript_include_tag "vendor/modernizr-2.8.3.custom"
 = javascript_include_tag  "//use.typekit.net/pya1hgl.js"
+= javascript_include_tag "https://www.omniref.com/nav.min.js"
+
 :javascript
   try{Typekit.load();}catch(e){}
 

--- a/source/layouts/regions/_banner.haml
+++ b/source/layouts/regions/_banner.haml
@@ -3,13 +3,13 @@
     %h1.site-brand= link_to (image_tag "logos/logo.svg", height: "48", alt: "Sass"), "/"
 
     %nav.navigation.collapse(role="navigation")
-      :markdown
-        * [Install](/install)
-        * [Learn Sass](/guide)
-        * [Blog](http://blog.sass-lang.com/)
-        * [Documentation](/documentation/file.SASS_REFERENCE.html)
-        * [Get Involved](/community)
-        * [libSass](/libsass)
+      %ul
+        %li= link_to "Install",       "/install"
+        %li= link_to "Learn Sass",    "/guide"
+        %li= link_to "Blog",          "http://blog.sass-lang.com/"
+        %li= link_to "Documentation", "https://www.omniref.com/ruby/gems/sass", data: {'omniref-gem' => 'sass'}
+        %li= link_to "Get Involved",  "/community"
+        %li= link_to "libSass",       "/libsass"
 
     .banner-toggle
       %button(type="button" data-toggle="collapse" data-target=".navigation")


### PR DESCRIPTION
Omniref is using scss liberally, and we'd love to find ways to contribute to the project. I've created a dynamic documentation menu to kick things off, but I think there's a lot more we can do to help out. In the meantime, I've poured myself some Old Weller 107, and poked around to make sure there was no perceivable change until hovering over the Documentation link. The dynamic navigation menu supports the existing responsive layout with the native sass styles and will be automatically updated whenever a new version of sass is published via ruby gems.

I've setup an idle dyno app on heroku if you'd like to play with the functionality (first request will be slow):

https://sass-omniref.herokuapp.com/

I'd appreciate any feedback you have.

Thanks!