### PR TITLE
Changing sticker alert to be about Camp Sass

### DIFF
--- a/source/layouts/roles/_alert.haml
+++ b/source/layouts/roles/_alert.haml
@@ -25,9 +25,19 @@
 -#          %button.url-responsive(type="button") Responsive Test
 -#
 
+// Commented out for Camp Sass alert.
+// Comment back in when Camp Sass is over.
+-# .alert.stickers
+-#   .container
+-#     %p
+-#       %strong Your laptop needs more Sass.
+-#       = succeed "." do
+-#         = link_to "Grab a set of Sass stickers now", "http://devswag.com/products/sass-stickers-4"
+
+// This can be deleted when Camp Sass is over.
 .alert.stickers
   .container
     %p
-      %strong Your laptop needs more Sass.
+      %strong Camp Sass is coming to Atlanta on April 4th.
       = succeed "." do
-        = link_to "Grab a set of Sass stickers now", "http://devswag.com/products/sass-stickers-4"
+        = link_to "Grab a ticket now", "http://campsass.com"


### PR DESCRIPTION
As Camp Sass is coming up, I was wondering if we could briefly alter the promotional alert about stickers to be about Camp Sass.

This PR changes the alert to read: "Camp Sass is coming to Atlanta on April 4th. Grab a ticket now." See screenshot below:

![screen shot 2015-03-23 at 9 26 57am](https://cloud.githubusercontent.com/assets/108884/6784763/e202ecc4-d13e-11e4-8ba8-429b10526441.png)

If you'd rather keep the sticker banner there, I can add a banner further down the page just above the release, like I did for last year's Camp Sass (see PR here: https://github.com/sass/sass-site/pull/63)