### PR TITLE
code-snippets, fix, comment type

### DIFF
--- a/source/code-snippets/_homepage-import-2-scss.md
+++ b/source/code-snippets/_homepage-import-2-scss.md
@@ -1,5 +1,5 @@
 ```scss
-/* base.scss */
+// base.scss
 
 @import 'reset';
 


### PR DESCRIPTION
Hi :)


Here: http://sass-lang.com/guide in the *Import* section, we can see a specific change about a comment between the `Sass` and the `SCSS` version of the code.

I suppose it's a mistake, because it's give the impression to be another difference between `Sass/SCSS` but not.
