### PR TITLE
Add link to Ghostlab to install page

### DIFF
--- a/source/install.html.haml
+++ b/source/install.html.haml
@@ -25,6 +25,11 @@ title: Install Sass
         %span.windows-icon
         %span.linux-icon
       %li
+        = link_to "Ghostlab", "http://www.vanamco.com/ghostlab/"
+        %span.info (Paid)
+        %span.mac-icon
+        %span.windows-icon
+      %li
         = link_to "Hammer", "http://hammerformac.com/"
         %span.info (Paid)
         %span.mac-icon


### PR DESCRIPTION
Hey there.

Our app, Ghostlab, offers support for precompiling projects using Sass. We'd be happy if you could include us in the list. The app is paid and runs on OS X and Windows.

There's a fully free, full-featured 7 day trial of Ghostlab, so you can verify that we support Sass available at http://www.vanamco.com/ghostlab. Feel free to ask any questions.

Thanks for considering this
Florian