### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ navigate to the project repo and run:
 
 ```
 bundle install
-middleman
+bundle exec middleman
 ```
 
 


### PR DESCRIPTION
Changed instructions to use the bundled middleman. It is likely the gem isn't globally installed and it isn't at least if just these instructions are followed.