### PR TITLE
Specify Ruby version to avoid encoding errors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ following:
 This site is built with [middleman](http://middlemanapp.com), a Ruby framework
 for building static sites.
 
-You will need [Ruby](https://www.ruby-lang.org/en/downloads/),
+You will need [Ruby 2](https://www.ruby-lang.org/en/downloads/),
 [rubygems](http://rubygems.org/) and [bundler](http://bundler.io/) installed
 before you can run the site locally.
 


### PR DESCRIPTION
#132 is caused by using an old Ruby when generating the docs. I have tested with Ruby 1.9 versus Ruby 2. The error shows up in 1.9, but not 2. 

Ruby starting with 2.0 does UTF-8 encoding by default. Earlier Ruby versions do not and this can cause the unicode quotes to turn into "???" when the docs are generated with an older Ruby.

