### PR TITLE
Added jsass under the Java implementations

### DIFF
--- a/source/libsass.html.haml
+++ b/source/libsass.html.haml
@@ -46,7 +46,9 @@ title: libSass
   %li#java
     :markdown
       ### Java
-      There is one Java wrapper – the [libSass Maven plugin](https://github.com/warmuuh/libsass-maven-plugin).
+      There are (at least) two Java wrappers:
+	  * the [libSass Maven plugin](https://github.com/warmuuh/libsass-maven-plugin);
+	  * the [jsass library](https://github.com/bit3/jsass).
 
   %li#javascript
     :markdown


### PR DESCRIPTION
I've been using jsass for a while now, but I noticed that it is not listed under the Java implementations. So I figured I might as well include it.