### PR TITLE
Change 'Sass Repo' link in footer to 'Sass on GitHub'

### DIFF
--- a/source/layouts/regions/_contentinfo.haml
+++ b/source/layouts/regions/_contentinfo.haml
@@ -14,7 +14,7 @@
 
         %li.contentinfo-tools
           %ul
-            %li= link_to "Sass Repo",            "https://github.com/sass/sass"
+            %li= link_to "Sass on GitHub",       "https://github.com/sass"
             %li= link_to "Website Repo",         "https://github.com/sass/sass-site"
             %li= link_to "Style Guide",          "/styleguide"
             %li= link_to "Community Guidelines", "/community-guidelines"


### PR DESCRIPTION
Fixes #151 