### PR TITLE
rewrote GoLang links

### DIFF
--- a/source/libsass.html.haml
+++ b/source/libsass.html.haml
@@ -37,11 +37,17 @@ title: libSass
   %li#go
     :markdown
       ### Go
-      [Wellington](https://github.com/wellington/wellington) is an extension to libsass that adds spriting and is available on brew:
+      [go-libsass](https://github.com/wellington/go-libsass) has the most active
+      GoLang wrapper.  [gosass](https://github.com/moovweb/gosass) is another
+      libsass wrapper.
+      
+      [Wellington](http://getwt.io/) is an extension to libsass that adds
+      spriting.  It is available on brew: `brew install wellington`
 
-      `brew install wellington`
-
-      There are also three other libsass wrappers in go: [gosass](https://github.com/moovweb/gosass), [go-sass](https://github.com/SamWhited/go-sass) and [go_sass](https://github.com/suapapa/go_sass) which have not been updated in a while.
+      [C6](https://github.com/c9s/c6) is a SASS 3.2 compatible implementation
+      written in pure GoLang that aims to extend SASS.
+      [wellington/sass](https://github.com/wellington/sass) is an in-progress
+      pure Go sass lexer, parser, and compiler.
 
   %li#java
     :markdown


### PR DESCRIPTION
removed abandoned Go Libsass wrappers
added pure GoLang compilers
