### PR TITLE
Change gem install command in Linux

### DIFF
--- a/source/install.html.haml
+++ b/source/install.html.haml
@@ -66,7 +66,7 @@ title: Install Sass
         first. You can install Ruby through the apt package manager, rbenv, or rvm.
         %pre
           :preserve
-            sudo su -c "gem install sass"
+            sudo gem install sass --no-user-install
 
     %dl#install-ruby-windows
       %dt Windows


### PR DESCRIPTION
The proposed command in the install page of the site:
`sudo su -c "gem install sass"`
neglects the fact that some gem packages come with `--user-install` in the default `/etc/gemrc`.
This command will install sass in the $HOME directory of the user root which is /root.
This makes sass available *only* to the Root user.
As expected, the following warning is given:
`WARNING:  You don't have /root/.gem/ruby/2.3.0/bin in your PATH,`
`	  gem executables will not run.`
By using the `--no-user-install` option it works correctly, as the gem is installed in $GEM_HOME instead as pointed out by `gem help install`
 