### PR TITLE
Update scout-app link on install page

### DIFF
--- a/source/install.html.haml
+++ b/source/install.html.haml
@@ -51,7 +51,7 @@ title: Install Sass
         %span.windows-icon
         %span.linux-icon
       %li
-        = link_to "Scout", "http://mhs.github.io/scout-app/"
+        = link_to "Scout", "http://scout-app.io/"
         %span.info (Open Source)
         %span.mac-icon
         %span.windows-icon


### PR DESCRIPTION
This fixes a dead link on the install page: http://sass-lang.com/install