### PR TITLE
Scout to Scout-App, OS Support updated

### DIFF
--- a/source/install.html.haml
+++ b/source/install.html.haml
@@ -51,10 +51,11 @@ title: Install Sass
         %span.windows-icon
         %span.linux-icon
       %li
-        = link_to "Scout", "http://scout-app.io/"
-        %span.info (Open Source)
-        %span.mac-icon
+        = link_to "Scout-App", "http://scout-app.io/"
+        %span.info (Free, Open Source)
         %span.windows-icon
+        %span.linux-icon
+        %span.mac-icon
 
   %li.command-line-unix
     %h3 Command Line


### PR DESCRIPTION
Scout has been rebranded to Scout-App. OS Support now includes Windows,
Linux, and OSX.