### PR TITLE
Update prefixe property

### DIFF
--- a/source/code-snippets/_homepage-mixins-sass.md
+++ b/source/code-snippets/_homepage-mixins-sass.md
@@ -1,10 +1,9 @@
 ```sass
-=border-radius($radius)
-  -webkit-border-radius: $radius
-  -moz-border-radius:    $radius
-  -ms-border-radius:     $radius
-  border-radius:         $radius
+=transform($method)
+  -webkit-transform: $method
+  -ms-transform:     $method
+  transform:         $method
 
 .box
-  +border-radius(10px)
+  +transform(rotate(30deg))
 ```


### PR DESCRIPTION
As it said http://shouldiprefix.com/#border-radius, border-radius doesn't need prefixes ! 

As you wrote in your [guide](http://sass-lang.com/guide), @mixin is theorically right but in pratice, prefixe border-radius is useless. I push requet to change it to make sass-site as right as possible! 

I purpose to use transform property (or anything else still in need of prefies)