### PR TITLE
Update _homepage-mixins-css.md

### DIFF
--- a/source/code-snippets/_homepage-mixins-css.md
+++ b/source/code-snippets/_homepage-mixins-css.md
@@ -1,8 +1,7 @@
 ```css
 .box {
-  -webkit-border-radius: 10px;
-  -moz-border-radius: 10px;
-  -ms-border-radius: 10px;
-  border-radius: 10px;
+  -webkit-transform: rotate(30deg);
+  -ms-border-transform: rotate(30deg);
+  border-transform: rotate(30deg);
 }
 ```


### PR DESCRIPTION
As it said http://shouldiprefix.com/#border-radius, border-radius doesn't need prefixes !

As you wrote in your guide, @mixin is theorically right but in pratice, prefixe border-radius is useless. I push requet to change it to make sass-site as right as possible!

I purpose to use transform property (or anything else still in need of prefies)