### PR TITLE
Update the Libsas links in the Intro

### DIFF
--- a/source/libsass.html.haml
+++ b/source/libsass.html.haml
@@ -4,12 +4,11 @@ title: LibSass
 
 %p.introduction
   We want everyone to enjoy Sass, no matter what language they use. Sass was
-  originally written in Ruby.
-  = link_to "LibSass", "http://libsass.org/"
-  is a C/C++ port of the Sass engine. The point is to be simple, faster, and
-  easy to integrate. Find out more about the project over at
+  originally written in Ruby. LibSass is a C/C++ port of the Sass engine. The
+  point is to be simple, faster, and easy to integrate. Find out more about the
+  project over at
   = succeed "." do
-    = link_to "GitHub", "http://github.com/hcatlin/libsass"
+    = link_to "GitHub", "http://github.com/sass/libsass"
 
 :markdown
   ## Wrappers


### PR DESCRIPTION
- libsass.org, just points back to this page
- the primary GitHub repo is under the Sass org now, so skip the redirect from Hampton's repo to the main repo