### PR TITLE
Fix broken link to Compass.app site

### DIFF
--- a/source/install.html.haml
+++ b/source/install.html.haml
@@ -19,7 +19,7 @@ title: Install Sass
         %span.info (Paid)
         %span.mac-icon
       %li
-        = link_to "Compass.app", "http://compass.handlino.com/"
+        = link_to "Compass.app", "http://compass.kkbox.com/"
         %span.info (Paid, Open Source)
         %span.mac-icon
         %span.windows-icon


### PR DESCRIPTION
Looks like the site has been moved to a different domain