### PR TITLE
Add jsass to the java wrappers

### DIFF
--- a/source/libsass.html.haml
+++ b/source/libsass.html.haml
@@ -63,7 +63,8 @@ title: LibSass
     :markdown
       ### Java
       There is one Java wrapper – [jsass](https://github.com/bit3/jsass).
-      There is also a plugin for Maven - [LibSass Maven plugin](https://github.com/warmuuh/libsass-maven-plugin).
+      There is also a plugin for Maven - 
+      [LibSass Maven plugin](https://github.com/warmuuh/libsass-maven-plugin).
 
   %li#javascript
     :markdown

--- a/source/libsass.html.haml
+++ b/source/libsass.html.haml
@@ -62,8 +62,8 @@ title: LibSass
   %li#java
     :markdown
       ### Java
-      There is one Java wrapper – the
-      [LibSass Maven plugin](https://github.com/warmuuh/libsass-maven-plugin).
+      There is one Java wrapper – [jsass](https://github.com/bit3/jsass).
+      There is also a plugin for Maven - [LibSass Maven plugin](https://github.com/warmuuh/libsass-maven-plugin).
 
   %li#javascript
     :markdown

--- a/source/libsass.html.haml
+++ b/source/libsass.html.haml
@@ -63,7 +63,7 @@ title: LibSass
     :markdown
       ### Java
       There is one Java wrapper – [jsass](https://github.com/bit3/jsass).
-      There is also a plugin for Maven - 
+      There is also a plugin for Maven -
       [LibSass Maven plugin](https://github.com/warmuuh/libsass-maven-plugin).
 
   %li#javascript


### PR DESCRIPTION
I have added jsass to the list of java wrapper.
It is also used by the libsass-maven-plugin now.

PS: I'm the developer and maintainer of jsass ;-)