### PR TITLE
Add SassMe project

### DIFF
--- a/data/community.yml
+++ b/data/community.yml
@@ -83,6 +83,9 @@ projects:
   - name: "SassDoc"
     url: "http://sassdoc.com/"
     description: "A documentation tool for Sass"
+  - name: "SassMe"
+    url: "http://jim-nielsen.com/sassme/"
+    description: "Visualize Sass color function output in real-time — no compiling!"
 
 articles:
   - name: "Sass vs. LESS"


### PR DESCRIPTION
Add a link to `/community` under the "Projects & Frameworks" heading to [SassMe](http://jim-nielsen.com/sassme/) ([project code on github](https://github.com/jimniels/sassme)) which lets you manipulate Sass color functions in the browser and visualize the output.

![screen shot 2017-04-26 at 8 57 30 am](https://cloud.githubusercontent.com/assets/1316441/25441581/d7d118d0-2a5f-11e7-9547-f0365e89eac1.png)

![screen shot 2017-04-26 at 9 08 26 am](https://cloud.githubusercontent.com/assets/1316441/25441626/f2ce3582-2a5f-11e7-930c-77b79d5cdffb.png)
