### PR TITLE
Update instructions and deps to allow building from fresh env.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,7 @@ navigate to the project repo and run:
 
 ```
 bundle install
+bundle exec rake import_sass
 bundle exec middleman
 ```
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.2.3'
+ruby '2.2.7'
 
 gem 'rake'
 gem 'rack'
@@ -23,6 +23,7 @@ group :development do
   gem 'typogruby',              '~> 1.0.18'
   gem 'tzinfo-data',            '~> 1.2015.7', platforms: [:mswin, :mingw, :jruby]
   gem 'wdm',                    '~> 0.1.1',    platforms: [:mswin, :mingw]
+  gem 'therubyracer',           '~> 0.12.3'
 end
 
 gem 'middleman-minify-html',    '~> 3.4.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,7 @@ GEM
     i18n (0.7.0)
     json (1.8.3)
     kramdown (1.9.0)
+    libv8 (3.16.14.19)
     listen (3.0.5)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
@@ -144,12 +145,13 @@ GEM
     rack-rewrite (1.5.1)
     rack-test (0.6.3)
       rack (>= 1.0)
-    rake (10.4.2)
+    rake (12.0.0)
     rb-fsevent (0.9.6)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
     react-source (0.13.3)
     redcarpet (3.3.3)
+    ref (2.0.0)
     rouge (1.10.1)
     rubypants (0.2.0)
     sass (3.4.20)
@@ -183,6 +185,9 @@ GEM
       tilt (~> 1.1)
     susy (2.2.9)
       sass (>= 3.3.0, < 3.5)
+    therubyracer (0.12.3)
+      libv8 (~> 3.16.14.15)
+      ref
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (1.4.1)
@@ -219,9 +224,13 @@ DEPENDENCIES
   rake
   redcarpet (~> 3.3.3)
   susy (~> 2.2.9)
+  therubyracer (~> 0.12.3)
   typogruby (~> 1.0.18)
   tzinfo-data (~> 1.2015.7)
   wdm (~> 0.1.1)
 
+RUBY VERSION
+   ruby 2.2.7p470
+
 BUNDLED WITH
-   1.11.2
+   1.15.0

--- a/Rakefile
+++ b/Rakefile
@@ -2,11 +2,9 @@
 # This is a helper function that properly sets up
 # the environment in the .sass folder for bundle commands to work
 def bundle(cmd)
-  old_bundle_gemfile = ENV["BUNDLE_GEMFILE"]
-  ENV.delete("BUNDLE_GEMFILE")
-  sh %{bundle #{cmd}}
-ensure
-  ENV["BUNDLE_GEMFILE"]
+  Bundler.with_clean_env do
+    sh %{bundle #{cmd}}
+  end
 end
 
 


### PR DESCRIPTION
Discovered some small issues with building sass-site from a fresh checkout while working on [https://github.com/sass/sass/issues/2295](this issue) with some broken links in the docs.

Made the following changes to get the project to build and run in a fresh environment.  

* Added therubyracer to Gemfile. Without a JS runtime, middleman won't start
* Bumped ruby version from 2.2.3 to 2.2.7
* Updated build instructions to include a step to build yard docs
* Simplified how Rakefile calls bundler, per http://bundler.io/v1.3/man/bundle-exec.1.html#Shelling-out

The change to Rakefile was not just cosmetic - the existing code would not run at all from a fresh checkout and found this while researching solution.