### PR TITLE
Fix case issue of 'Github' vs 'GitHub' (completes #183)

### DIFF
--- a/source/layouts/layout.haml
+++ b/source/layouts/layout.haml
@@ -35,7 +35,7 @@
             - else
               %li Current Release: <span class="release-name">???</span>
             %li= link_to "Release Notes", "/documentation/file.SASS_CHANGELOG.html"
-            %li= link_to "Fork on Github", "https://github.com/sass/sass"
+            %li= link_to "Fork on GitHub", "https://github.com/sass/sass"
             %li= link_to "Implementation Guide", "implementation"
 
       - if content_for?(:section_bottom)

--- a/source/layouts/layout_2_column.haml
+++ b/source/layouts/layout_2_column.haml
@@ -40,7 +40,7 @@
             - else
               %li Current Release: <span class="release-name">???</span>
             %li= link_to "Release Notes", "/documentation/file.SASS_CHANGELOG.html"
-            %li= link_to "Fork on Github", "https://github.com/sass/sass"
+            %li= link_to "Fork on GitHub", "https://github.com/sass/sass"
             %li= link_to "Implementation Guide", "implementation"
 
       - if content_for?(:section_bottom)

--- a/source/layouts/responsive_test.haml
+++ b/source/layouts/responsive_test.haml
@@ -58,7 +58,7 @@
             - else
               %li Current Release: <span class="release-name">???</span>
             %li= link_to "Release Notes", "/documentation/file.SASS_CHANGELOG.html"
-            %li= link_to "Fork on Github", "https://github.com/sass/sass"
+            %li= link_to "Fork on GitHub", "https://github.com/sass/sass"
             %li= link_to "Implementation Guide", "implementation"
 
       - if content_for?(:section_bottom)

--- a/source/layouts/styleguide.haml
+++ b/source/layouts/styleguide.haml
@@ -72,7 +72,7 @@
             - else
               %li Current Release: <span class="release-name">???</span>
             %li= link_to "Release Notes", "/documentation/file.SASS_CHANGELOG.html"
-            %li= link_to "Fork on Github", "https://github.com/sass/sass"
+            %li= link_to "Fork on GitHub", "https://github.com/sass/sass"
             %li= link_to "Implementation Guide", "implementation"
 
       - if content_for?(:section_bottom)


### PR DESCRIPTION
This PR finishes the text cleanup started on #183 