### PR TITLE
Clarifies directory syntax in sass command

### DIFF
--- a/source/guide.html.haml
+++ b/source/guide.html.haml
@@ -28,20 +28,36 @@ title: Sass Basics
       CSS on its own can be fun, but stylesheets are getting larger, more
       complex, and harder to maintain. This is where a preprocessor can help.
       Sass lets you use features that don't exist in CSS yet like variables,
-      nesting, mixins, inheritance and other nifty goodies that make writing CSS
-      fun again.
+      nesting, mixins, inheritance and other nifty goodies that make writing
+      CSS fun again.
 
       Once you start tinkering with Sass, it will take your preprocessed Sass
       file and save it as a normal CSS file that you can use in your
-      web&nbsp;site.
+      website.
 
       The most direct way to make this happen is in your terminal. Once Sass is
-      installed, you can run `sass input.scss output.css` from your terminal.
-      You can watch either individual files or entire directories. In addition,
-      you can watch folders or directories with the `--watch` flag. An example
-      of running Sass while watching an entire directory is the following:
+      installed, you can compile your Sass to CSS using the `sass` command.
+      You'll need to tell Sass which file to build from, and where to output
+      CSS to. For example, running `sass input.scss output.css` from your
+      terminal would take a single Sass file, `input.scss`, and compile that
+      file to `output.css`.
+
+      You can also watch individual files or directories with the `--watch`
+      flag. The watch flag tells Sass to watch your source files for
+      changes, and re-compile CSS each time you save your Sass. If you wanted
+      to watch (instead of manually build) your `input.scss` file, you'd just
+      add the watch flag to your command, like so:
+
+      `sass --watch input.scss output.css`
+
+      You can watch and output to directories by using folder paths as your
+      input and output, and separating them with a colon. In this example:
 
     ~ partial "code-snippets/homepage-sass-watch"
+
+    :markdown
+      Sass would watch all files in the `app/sass` folder for changes, and
+      compile CSS to the `public/stylesheets` folder.
 
     %hr/
 


### PR DESCRIPTION
Fixes https://github.com/sass/sass-site/issues/190 with clearer instructions on `sass` and the `--watch` flag, intros the concept of watching for people who might not have worked with preprocessors before, and clarifies the syntax for building/watching to and from directories.