### PR TITLE
Add sass-extract to community links

### DIFF
--- a/data/community.yml
+++ b/data/community.yml
@@ -86,6 +86,9 @@ projects:
   - name: "SassMe"
     url: "http://jim-nielsen.com/sassme/"
     description: "Visualize Sass color function output in real-time — no compiling!"
+  - name: "sass-extract"
+    url: "https://github.com/jgranstrom/sass-extract"
+    description: "Extract sass variables for use in javascript"
 
 articles:
   - name: "Sass vs. LESS"

--- a/data/community.yml
+++ b/data/community.yml
@@ -88,7 +88,7 @@ projects:
     description: "Visualize Sass color function output in real-time — no compiling!"
   - name: "sass-extract"
     url: "https://github.com/jgranstrom/sass-extract"
-    description: "Extract sass variables for use in javascript"
+    description: "Extract Sass variables for use in JavaScript"
 
 articles:
   - name: "Sass vs. LESS"


### PR DESCRIPTION
Adds a link to sass-extract, a tool that uses native sass features to extract computed variable values for use in javascript for things such as complex visualisations or dynamic theme functionality