### PR TITLE
Add sass.cr to the list of LibSass wrappers

### DIFF
--- a/source/libsass.html.haml
+++ b/source/libsass.html.haml
@@ -16,7 +16,7 @@ title: LibSass
   LibSass is just a library. To run the code locally (i.e. to compile your
   stylesheets), you need an implementer, or "wrapper". There are a number of
   other wrappers for LibSass. We encourage you to write your own wrapper - the
-  whole point of Libsass is that we want to bring Sass to many other languages,
+  whole point of LibSass is that we want to bring Sass to many other languages,
   not just Ruby!
 
   Below are the LibSass wrappers that we're currently aware of. Sometimes there
@@ -28,7 +28,7 @@ title: LibSass
     :markdown
       ### Sass C
 
-      [SassC](https://github.com/sass/sassc) (get it?) is an wrapper written in
+      [SassC](https://github.com/sass/sassc) (get it?) is a wrapper written in
       C.
 
       To run the compiler on your local machine, you need to build SassC. To
@@ -45,6 +45,13 @@ title: LibSass
 
     ~ partial "code-snippets/libsass-execute"
 
+  %li#crystal
+    :markdown
+      ### Crystal
+      [sass.cr](https://github.com/straight-shoota/sass.cr)
+      is a LibSass wrapper for the
+      [Crystal programming language](https://crystal-lang.org/).
+
   %li#go
     :markdown
       ### Go
@@ -53,7 +60,7 @@ title: LibSass
 
       `brew install wellington`
 
-      There are also three other LibSass wrappers in go:
+      There are also three other LibSass wrappers in Go:
       [gosass](https://github.com/moovweb/gosass),
       [go-sass](https://github.com/SamWhited/go-sass) and
       [go_sass](https://github.com/suapapa/go_sass) which have not been updated
@@ -77,7 +84,7 @@ title: LibSass
   %li#lua
     :markdown
       ### Lua
-      The lua wrapper is found at
+      The Lua wrapper is found at
       [lua-sass](https://github.com/craigbarnes/lua-sass).
 
   %li#net
@@ -115,13 +122,13 @@ title: LibSass
   %li#python
     :markdown
       ### Python
-      There are two python projects that are updated regularly. The
+      There are two Python projects that are updated regularly. The
       [libsass-python](https://github.com/dahlia/libsass-python) project (there
       are more details on
       [its own website](http://hongminhee.org/libsass-python/)) and the
       [python-scss](https://github.com/pistolero/python-scss) project.
 
-      Two other python projects,
+      Two other Python projects,
       [pylibsass](https://github.com/rsenk330/pylibsass) and
       [SassPython](https://github.com/marianoguerra/SassPython), haven't been
       updated in a while.
@@ -130,13 +137,13 @@ title: LibSass
   %li#ruby
     :markdown
       ### Ruby
-      LibSass has also been ported back into ruby, for the
+      LibSass has also been ported back into Ruby for the
       [sassc-ruby](https://github.com/sass/sassc-ruby) project.
 
   %li#scala
     :markdown
       ### Scala
-      The only scala project, [Sass-Scala](https://github.com/kkung/Sass-Scala),
+      The only Scala project, [Sass-Scala](https://github.com/kkung/Sass-Scala),
       hasn't been updated in a couple of years.
 
 %h2 About LibSass
@@ -155,6 +162,7 @@ title: LibSass
   %h3 Wrappers
   %ul.anchors
     %li= link_to "SassC",      "#sassc"
+    %li= link_to "Crystal",    "#crystal"
     %li= link_to "Go",         "#go"
     %li= link_to "Java",       "#java"
     %li= link_to "JavaScript", "#javascript"


### PR DESCRIPTION
This pull request adds [sass.cr](https://github.com/straight-shoota/sass.cr) to the list of LibSass wrappers. I also fixed some typos as I found them.