### PR TITLE
Update border-radius mixin in guide.html.haml

### DIFF
--- a/source/guide.html.haml
+++ b/source/guide.html.haml
@@ -193,7 +193,7 @@ title: Sass Basics
       the many vendor prefixes that exist. A mixin lets you make groups of CSS
       declarations that you want to reuse throughout your site. You can even
       pass in values to make your mixin more flexible. A good use of a mixin is
-      for vendor prefixes. Here's an example for <code>border-radius</code>.
+      for vendor prefixes. Here's an example for <code>transform</code>.
 
     %ul
       %li= link_to "SCSS", "#topic-6-SCSS"


### PR DESCRIPTION
Fixes a documentation bug. https://github.com/sass/sass-site/pull/176 changed the property from `border-radius` to `transform`, but the text in the guide was not updated to reflect this change.