### PR TITLE
Remove --devel from "brew install"

### DIFF
--- a/source/install.html.haml
+++ b/source/install.html.haml
@@ -122,4 +122,4 @@ title: Install Sass
 
         %pre
           :preserve
-            brew install --devel sass/sass/sass
+            brew install sass/sass/sass


### PR DESCRIPTION
Dart Sass is stable now so this isn't necessary.