### PR TITLE
Delete extraneous backslashes in Import section

### DIFF
--- a/source/guide.html.haml
+++ b/source/guide.html.haml
@@ -142,8 +142,8 @@ introduction: >
       will take the file that you want to import and combine it with the file
       you're importing into so you can serve a single CSS file to the web browser.
 
-      Let's say you have a couple of Sass files, `\_reset.scss` and `base.scss`.
-      We want to import `\_reset.scss` into `base.scss`.
+      Let's say you have a couple of Sass files, `_reset.scss` and `base.scss`.
+      We want to import `_reset.scss` into `base.scss`.
 
     - example do
       :plain


### PR DESCRIPTION
Fixes an issue where some backslashes snuck into the new docs:

![screenshot_2018-11-28_23_14_55](https://user-images.githubusercontent.com/85783/49205380-b3e15100-f363-11e8-8121-095e8b0ddd74.png)
