### PR TITLE
Rewrite python section.

### DIFF
--- a/source/libsass.html.haml
+++ b/source/libsass.html.haml
@@ -122,13 +122,12 @@ title: LibSass
   %li#python
     :markdown
       ### Python
-      There are two Python projects that are updated regularly. The
-      [libsass-python](https://github.com/sass/libsass-python) project (there
-      are more details on
-      [its own website](https://sass.github.io/libsass-python/)) and the
-      [python-scss](https://github.com/pistolero/python-scss) project.
+      The [libsass-python](https://github.com/sass/libsass-python) project
+      is updated regularly. There are more details on
+      [its own website](https://sass.github.io/libsass-python/).
 
-      Two other Python projects,
+      Three other Python projects,
+      [python-scss](https://github.com/pistolero/python-scss),
       [pylibsass](https://github.com/rsenk330/pylibsass) and
       [SassPython](https://github.com/marianoguerra/SassPython), haven't been
       updated in a while.


### PR DESCRIPTION
The last commit to `python-scss` dates back to 2014.