### PR TITLE
Update the brew command to install sass with one command

### DIFF
--- a/source/install.html.haml
+++ b/source/install.html.haml
@@ -122,4 +122,4 @@ title: Install Sass
 
         %pre
           :preserve
-            brew install sass/sass/sass
+            brew tap sass/sass && brew install sass/sass/sass


### PR DESCRIPTION
The brew command on the install page does not work and will result in a error that will ask new users to tap it first.

<img width="566" alt="image" src="https://user-images.githubusercontent.com/5509155/52164087-341d8d00-26ec-11e9-9a23-54f8e72f67c0.png">

Adding the tap first and then installing sass will work, but the currrent path is not optimal.
Therefore i suggest changing the command.