### PR TITLE
Enable Algolia search

### DIFF
--- a/helpers/sass_helpers.rb
+++ b/helpers/sass_helpers.rb
@@ -1,5 +1,7 @@
 # coding: utf-8
 require "pathname"
+require "set"
+
 require "redcarpet"
 require "rouge"
 require "rouge/plugins/redcarpet"
@@ -349,20 +351,28 @@ module SassHelpers
   # Multiple signatures may be passed, in which case they're all included in
   # sequence.
   def function(*signatures, returns: nil)
-    names = []
+    names = Set.new
     highlighted_signatures = signatures.map do |signature|
       name = signature.split("(").first
-      names << name
       html = Nokogiri::HTML(_render_markdown(<<MARKDOWN))
 ```scss
 @function #{signature}
 {}
 ```
 MARKDOWN
-      highlighted_signature = html.css("pre code").children.
+      signature_elements = html.css("pre code").children.
         drop_while {|el| el.text != "@function"}.
-        take_while {|el| el.text != "{}"}[1...-1].
-        map(&:to_html).join.strip
+        take_while {|el| el.text != "{}"}[1...-1]
+
+      # Add a class to make it easier to index function documentation.
+      unless names.include?(name)
+        names << name
+        name_element = signature_elements.find {|el| el.text == name}
+        name_element.add_class '.docSearch-function'
+        name_element['name'] = name
+      end
+
+      highlighted_signature = signature_elements.map(&:to_html).join.strip
     end
 
     html = content_tag :div, [

--- a/helpers/sass_helpers.rb
+++ b/helpers/sass_helpers.rb
@@ -368,11 +368,11 @@ MARKDOWN
       unless names.include?(name)
         names << name
         name_element = signature_elements.find {|el| el.text == name}
-        name_element.add_class '.docSearch-function'
+        name_element.add_class ".docSearch-function"
         name_element['name'] = name
       end
 
-      highlighted_signature = signature_elements.map(&:to_html).join.strip
+      signature_elements.map(&:to_html).join.strip
     end
 
     html = content_tag :div, [

--- a/source/layouts/has_both_sidebars.haml
+++ b/source/layouts/has_both_sidebars.haml
@@ -12,7 +12,7 @@
               %aside.sl-l-large-holy-grail__complementary(role='complementary'){class: has_contents}
                 = yield_content :complementary
 
-            .sl-l-large-holy-grail__main
+            .sl-l-large-holy-grail__main.docSearch-content
               - container = current_page.data.no_container ? '' : 'sl-l-container sl-l-container--small'
               %div{class: container}
                 - if current_page.data.introduction

--- a/source/layouts/layout.haml
+++ b/source/layouts/layout.haml
@@ -8,6 +8,7 @@
     %meta(name='viewport' content='width=device-width, initial-scale=1')
 
     = stylesheet_link_tag 'https://fonts.googleapis.com/css?family=Source+Code+Pro|Source+Sans+Pro:300,400,600|Source+Serif+Pro'
+    = stylesheet_link_tag 'https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css'
     = stylesheet_link_tag 'sass'
     = yield_content :css
 
@@ -68,6 +69,7 @@
               - [Blog](http://blog.sass-lang.com/)
               - [Documentation](/documentation)
               - [Get Involved](/community)
+              - <input class='search' type='text'>
 
     %main.content(itemprop='mainContentOfPage' role='main')
       %h1.sl-l-container
@@ -143,6 +145,14 @@
             :javascript
               !function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');
 
+    = javascript_include_tag 'https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js'
+    :javascript
+      docsearch({
+        apiKey: 'a409ff5d6a2476083c1a8dd1f8c04ec5',
+        indexName: 'sass-lang',
+        inputSelector: 'input.search',
+        debug: false
+      });
     = javascript_include_tag 'vendor/modernizr.custom.min'
     = javascript_include_tag 'vendor/jquery.min'
     = javascript_include_tag 'vendor/jquery-ui.min'


### PR DESCRIPTION
This adds:

* Algolia bootstrap JS.
* A search bar (without styling)
* A "docSearch-content" class to the main reference doc container, so
  the sidebars don't get indexed.
* A "docSearch-function" class to function names, so that they'll be
  indexed.

See #154