### PR TITLE
Add a light border to callouts

### DIFF
--- a/source/assets/css/components/_callouts.scss
+++ b/source/assets/css/components/_callouts.scss
@@ -2,10 +2,17 @@
   margin: 1.5rem 0;
   padding: 1.5rem 1rem;
   background: lighten($sl-color--pale-sky, 50%);
+  border-radius: 2px;
 
-  &--warning { background: lighten($sl-color--hopbush, 36%); }
+  &--warning {
+    background: lighten($sl-color--hopbush, 36%);
+    border: 1px solid lighten($sl-color--hopbush, 27%);
+  }
 
-  &--fun-fact { background: lighten($sl-color--patina, 43%); }
+  &--fun-fact {
+    background: lighten($sl-color--patina, 43%);
+    border: 1px solid lighten($sl-color--patina, 32%);
+  }
 
   &--function {
     padding: {


### PR DESCRIPTION
This helps them stand out a tiny bit more, especially in functions
where their backgrounds are very similar to the function background.