### PR TITLE
Don't make syntax switcher arrows invisible in callouts

### DIFF
--- a/source/assets/css/components/_sass-syntax-switcher.scss
+++ b/source/assets/css/components/_sass-syntax-switcher.scss
@@ -126,10 +126,6 @@ html .ui-button.ui-state-disabled:active { background: none; }
   .ui-button { color: inherit; }
 
   .ui-widget a { border: 0; }
-
-  .ui-tabs .ui-tabs-nav li.css-tab a::before {
-    color: rgba(white, .5);
-  }
 }
 
 .ui-tabs-panel > h3 {


### PR DESCRIPTION
I'm not sure why this was done initially, but it seems wrong?