### PR TITLE
Fix a broken function example

### DIFF
--- a/source/documentation/at-rules/function.html.md.erb
+++ b/source/documentation/at-rules/function.html.md.erb
@@ -164,7 +164,7 @@ argument is known as an [argument list][].
 
 <% example do %>
   @function sum($numbers...) {
-    $sum: null;
+    $sum: 0;
     @each $number in $numbers {
       $sum: $sum + $number;
     }
@@ -176,7 +176,7 @@ argument is known as an [argument list][].
   }
   ===
   @function sum($numbers...)
-    $sum: null
+    $sum: 0
     @each $number in $numbers
       $sum: $sum + $number
 

--- a/source/documentation/at-rules/function.html.md.erb
+++ b/source/documentation/at-rules/function.html.md.erb
@@ -163,32 +163,28 @@ argument is known as an [argument list][].
 [argument list]: ../values/lists#argument-lists
 
 <% example do %>
-  @function min($numbers...) {
-    $min: null;
+  @function sum($numbers...) {
+    $sum: null;
     @each $number in $numbers {
-      @if $min == null or $number < $min {
-        $min: $number;
-      }
+      $sum: $sum + $number;
     }
-    @return $min;
+    @return $sum;
   }
 
   .micro {
-    width: min(50px, 30px, 100px);
+    width: sum(50px, 30px, 100px);
   }
   ===
-  @function min($numbers...)
-    $min: null
+  @function sum($numbers...)
+    $sum: null
     @each $number in $numbers
-      @if $min == null or $number < $min
-        $min: $number
+      $sum: $sum + $number
 
-
-    @return $min
+    @return $sum
 
 
   .micro
-    width: min(50px, 30px, 100px)
+    width: sum(50px, 30px, 100px)
 <% end %>
 
 #### Taking Arbitrary Keyword Arguments


### PR DESCRIPTION
A "min" function conflicts with Sass's support for CSS's min() syntax.

Closes #335