### PR TITLE
Docs: Fix `to-lower-case` code example

### DIFF
--- a/source/documentation/functions/string.html.md.erb
+++ b/source/documentation/functions/string.html.md.erb
@@ -112,11 +112,11 @@ title: String Functions
   [ASCII]: https://en.wikipedia.org/wiki/ASCII
 
   <% example(autogen_css: false) do %>
-    @debug to-upper-case("Bold"); // "bold"
-    @debug to-upper-case(SANS-SERIF); // sans-serif
+    @debug to-lower-case("Bold"); // "bold"
+    @debug to-lower-case(SANS-SERIF); // sans-serif
     ===
-    @debug to-upper-case("Bold")  // "bold"
-    @debug to-upper-case(SANS-SERIF)  // sans-serif
+    @debug to-lower-case("Bold")  // "bold"
+    @debug to-lower-case(SANS-SERIF)  // sans-serif
   <% end %>
 <% end %>
 


### PR DESCRIPTION
Minor fix: `to-lower-case` featured a `to-upper-case` example