### PR TITLE
Fix implementation guide link in CONTRIBUTING.md, remove leftover obsolete half-sentence in styleguide/code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Contributing to the Sass website
 The Sass website is open source. See a bug or typo? Have an idea? Do the
 following:
 
-* **Please read the [Implementation Guide][sg] and the [Style Guide][sg]**
+* **Please read the [Implementation Guide][ig] and the [Style Guide][sg]**
   before contributing.
 * Write a detailed description of what you're adding in the pull request
   (screenshots help).

--- a/source/styleguide/code.html.md
+++ b/source/styleguide/code.html.md
@@ -35,7 +35,6 @@ otherwise.
     much simpler set:
     - `c-` is for **components**. Example: `sl-c-card`.
     - `l-` is for **layouts**. Example: `sl-l-grid`.
-      this double-dash syntax in a bit).
     - `is-` and `has-` for states. Example: `sl-is-active`.
     - `js-` is for classes specifically created for JavaScript targeting.
       Exampe: `sl-js-toggle-navigation`


### PR DESCRIPTION
Two minor fixes:
- Fix link to implementation guide in CONTRIBUTING.md
- styleguide/code: Remove obsolete line forgotten in 92d9baf 