### PR TITLE
Fixes correct version of libsass for index imports

### DIFF
--- a/source/documentation/at-rules/import.html.md.erb
+++ b/source/documentation/at-rules/import.html.md.erb
@@ -129,7 +129,7 @@ leave off the `_` when importing a partial.
 
 ### Index Files
 
-<% impl_status dart: true, libsass: '3.5.0', ruby: '3.6.0' %>
+<% impl_status dart: true, libsass: '3.6.0', ruby: '3.6.0' %>
 
 If you write an `_index.scss` or `_index.sass` in a folder, when the folder
 itself is imported that file will be loaded in its place.


### PR DESCRIPTION
This feature actually implemented only in libsass 3.6.0
https://github.com/sass/libsass/releases/tag/3.6.0

here's the commit `[3af837c] Add support for index imports (@xzyfer)`