### PR TITLE
Fix links in the migrator doc

### DIFF
--- a/source/documentation/cli/migrator.html.md.erb
+++ b/source/documentation/cli/migrator.html.md.erb
@@ -110,6 +110,8 @@ Migrating _grid.scss
   `--migrate-deps` option is passed.
 
   [module migrator]: #module
+  [`@use` rule]: ../at-rules/use
+  [`@forward` rule]: ../at-rules/forward
 <% end %>
 
 ### `--load-path`


### PR DESCRIPTION
It looks like the heads_up creates its own scope for link targets:
![image](https://user-images.githubusercontent.com/439401/66032516-d012c900-e505-11e9-8424-c810d90e4cc8.png)
