### PR TITLE
Remove simply from docs

### DIFF
--- a/source/guide.html.haml
+++ b/source/guide.html.haml
@@ -154,7 +154,7 @@ introduction: >
 
     You can create partial Sass files that contain little snippets of CSS that
     you can include in other Sass files. This is a great way to modularize
-    your CSS and help keep things easier to maintain. A partial is simply a
+    your CSS and help keep things easier to maintain. A partial is a
     Sass file named with a leading underscore. You might name it something
     like `_partial.scss`. The underscore lets Sass know that the file is only
     a partial file and that it should not be generated into a CSS file. Sass

--- a/source/libsass.html.haml
+++ b/source/libsass.html.haml
@@ -37,7 +37,7 @@ introduction: >
     = partial 'code-snippets/libsass-setup'
 
     :markdown
-      The executable will be in the bin folder. To run it, simply try something
+      The executable will be in the bin folder. To run it, try something
       like:
 
     = partial 'code-snippets/libsass-execute'


### PR DESCRIPTION
Based on [words to avoid in technical writing](https://css-tricks.com/advice-for-technical-writing/#article-header-id-8), removing "simply" from documentation. I can go through and remove other words like "just" or "so" where appropriate if that would be helpful too. 

I ran the site locally and confirmed the changes appeared as expected. 