### PR TITLE
[hotfix-387] Fix broken toggle

### DIFF
--- a/source/assets/js/components/navigation.js
+++ b/source/assets/js/components/navigation.js
@@ -6,7 +6,7 @@
 
   // Added sticky class when window top is great than nav top
   function stickyNav() {
-    if ($(window).scrollTop() >= sticky.top) {
+    if ( nav.length > 0 && $(window).scrollTop() >= sticky.top) {
       $(".sl-l-medium-holy-grail__body").addClass("sl-js-nav--is-sticky");
     } else {
       $(".sl-l-medium-holy-grail__body").removeClass("sl-js-nav--is-sticky");

--- a/source/assets/js/components/navigation.js
+++ b/source/assets/js/components/navigation.js
@@ -6,7 +6,7 @@
 
   // Added sticky class when window top is great than nav top
   function stickyNav() {
-    if ( nav.length > 0 && $(window).scrollTop() >= sticky.top) {
+    if (nav.length > 0 && $(window).scrollTop() >= sticky.top) {
       $(".sl-l-medium-holy-grail__body").addClass("sl-js-nav--is-sticky");
     } else {
       $(".sl-l-medium-holy-grail__body").removeClass("sl-js-nav--is-sticky");


### PR DESCRIPTION
Sass/Scss toggle wasn't working due to this error: 
```sass-0ff6f16f.js:23 Uncaught TypeError: Cannot read property 'top' of undefined```. 

Added conditional to check if `.sl-c-list-navigation-wrapper` is on the page before running the rest of `stickyNav`.

Closes #387 