### PR TITLE
[hotfix-400] Fix guide page scss/sass toggle 

### DIFF
--- a/source/assets/js/components/navigation.js
+++ b/source/assets/js/components/navigation.js
@@ -1,5 +1,5 @@
 // Documentation Nav Scroll
-(function docNav() {
+$(function() {
   // Vars
   var nav = $(".sl-c-list-navigation-wrapper");
   var sticky = nav.offset();
@@ -19,4 +19,4 @@
     });
 
   return stickyNav();
-})();
+});


### PR DESCRIPTION
**Summary:**

The scss/sass toggle was broken because of this error:

```bash
jQuery.Deferred exception: e is not a function TypeError: e is not a function
    at d (https://sass-lang.com/assets/js/sass-9bce6945.js:3:6813) undefined
```

To fix this issue, I made the function in `navigation.js` to anonymous function.

Closes #400 
