### PR TITLE
Increase the indent size for function definition docs.

### DIFF
--- a/source/assets/css/components/_callouts.scss
+++ b/source/assets/css/components/_callouts.scss
@@ -15,12 +15,15 @@
   }
 
   &--function {
-  padding: 0 2.25rem .25rem;
+    padding-bottom: .25rem;
+    padding-top: 0;
 
     .signature {
       // Make sure permalinks are visible.
       overflow: visible;
-      margin-left: -2.25rem;
+
+      margin-left: -1rem;
+      margin-right: -1rem;
     }
   }
 
@@ -44,5 +47,16 @@
     font-size: 1.25rem;
 
     .sl-c-callout { font-size: 1rem; }
+  }
+}
+
+@include sl-breakpoint--large {
+  .sl-c-callout--function {
+    padding-left: 2.25rem;
+
+    .signature {
+      margin-left: -2.25rem;
+      margin-right: 0;
+    }
   }
 }

--- a/source/assets/css/components/_callouts.scss
+++ b/source/assets/css/components/_callouts.scss
@@ -15,19 +15,12 @@
   }
 
   &--function {
-    padding: {
-      top: 0;
-      bottom: .25rem;
-    };
+  padding: 0 2.25rem .25rem;
 
     .signature {
       // Make sure permalinks are visible.
       overflow: visible;
-
-      margin: {
-        right: -1rem;
-        left: -1rem;
-      };
+      margin-left: -2.25rem;
     }
   }
 


### PR DESCRIPTION
While updating the math functions documentation, I realized that the large amount of text is making it hard to navigate the docs.

Increasing the indent size seems to improve readability. Attached are before/after pics to show the difference.

![docs-before](https://user-images.githubusercontent.com/3211874/72555465-75517300-3851-11ea-8e87-1d6bb851ef57.png)

![docs-after](https://user-images.githubusercontent.com/3211874/72555470-771b3680-3851-11ea-82d8-db76a6a4dfb3.png)
