### PR TITLE
[Resources page] Remove link to Sass News

### DIFF
--- a/source/community.html.haml
+++ b/source/community.html.haml
@@ -52,9 +52,6 @@ introduction: >
     :markdown
       ## Resources
 
-      ### [Sass News](http://sass.news/)
-      Sass community newsletter curated by Sass core team designer, [Jina Anne](https://www.sushiandrobots.com)
-
       ### [Jump Start Sass] (https://amzn.to/2LKF0uR)
       by Hugo Giraudel and Miriam Suzanne
 


### PR DESCRIPTION
Sass News was recently deprecated, RIP ❤️