### PR TITLE
Add Black Lives Matters statement

### DIFF
--- a/source/layouts/layout.haml
+++ b/source/layouts/layout.haml
@@ -48,13 +48,12 @@
         to improve your experience and security.
 
     %header.sl-r-banner(itemtype='http://schema.org/WPHeader' itemscope='itemscope' role='banner')
-      .sl-c-alert.sl-c-alert--info
+      .sl-c-alert.sl-c-alert--info(style='background: #000; padding: 3rem 0; text-align: left;')
         .sl-l-container
+          %h2(style='margin-top: 0;') Black Lives Matter
+          
           %p
-            Sass just launched a brand new module system.
-            = succeed '!' do
-              = link_to '/blog/the-module-system-is-launched' do
-                Learn all about the module system on the Sass blog
+            Sass stands with with the protesters against police violence. We encourage our users to get in the streets and join them if you can.
 
       .sl-c-pop-stripe
       .sl-l-container

--- a/source/layouts/layout.haml
+++ b/source/layouts/layout.haml
@@ -55,7 +55,7 @@
           %p
             Sass stands with with the protesters against police violence. We encourage our users to 
             = succeed '.' do
-              %strong get in the streets and join them if you can.
+              %strong get in the streets and join them if you can
 
       .sl-c-pop-stripe
       .sl-l-container

--- a/source/layouts/layout.haml
+++ b/source/layouts/layout.haml
@@ -53,7 +53,9 @@
           %h2(style='margin-top: 0;') Black Lives Matter
           
           %p
-            Sass stands with with the protesters against police violence. We encourage our users to get in the streets and join them if you can.
+            Sass stands with with the protesters against police violence. We encourage our users to 
+            = succeed '.' do
+              %strong get in the streets and join them if you can.
 
       .sl-c-pop-stripe
       .sl-l-container


### PR DESCRIPTION
Swaps top banner out for Black Lives Matter messaging with inline styles for stylistic tweaks since these styles won't need to be added to the main global styles.

<img width="1680" alt="Screenshot 2020-06-01 17 02 26" src="https://user-images.githubusercontent.com/53273/83465776-dc02b200-a429-11ea-9d00-1a0eda461322.png">
