### PR TITLE
Simplify copyright statement

### DIFF
--- a/source/layouts/layout.haml
+++ b/source/layouts/layout.haml
@@ -127,10 +127,8 @@
         .sl-l-grid.sl-l-grid--full.sl-l-large-grid--fit.sl-l-large-grid--center.sl-l-large-grid--gutters
           .sl-l-grid__column
             :markdown
-              Sass &copy; 2006&ndash;#{Date.today.year} [Hampton Catlin][hampton],
-              [Natalie Weizenbaum][natalie], [Chris Eppstein][chris],
-              [Jina Anne][jina], and numerous contributors. It is available for use
-              and modification under the [MIT&nbsp;License][license].
+              Sass &copy; 2006&ndash;#{Date.today.year} the Sass team, and numerous contributors. 
+              It is available for use and modification under the [MIT&nbsp;License][license].
 
               [hampton]: https://github.com/hcatlin
               [natalie]: https://twitter.com/nex3


### PR DESCRIPTION
Switching the explicitly named team members for "the Sass team" so it has longevity.