### PR TITLE
Remove Chocolatey install instructions

### DIFF
--- a/source/install.html.haml
+++ b/source/install.html.haml
@@ -116,17 +116,6 @@ no_container: true
         easy to swap in another implementation later if you need a bit more
         speed!
 
-      %dt Install on Windows (Chocolatey)
-
-      %dd
-        %p
-          If you use <a href='https://chocolatey.org/'>the Chocolatey package
-          manager</a> for Windows, you can install Dart Sass by running
-
-        %pre
-          :preserve
-            choco install sass
-
       %dt Install on Mac OS X (Homebrew)
 
       %dd


### PR DESCRIPTION
The Chocolatey release has been out of date for months, so we shouldn't be recommending it until we're able to reliably keep it up to date.