### PR TITLE
Removed unnecessary line separator character

### DIFF
--- a/source/styleguide/index.html.md
+++ b/source/styleguide/index.html.md
@@ -7,5 +7,5 @@ introduction: >
 
 ### Site Objectives
 
-1. Show why Sass is the best CSS Preprocessor,  and why you should use it.
+1. Show why Sass is the best CSS Preprocessor, and why you should use it.
 2. Be a resource for those who are already using Sass, at whatever level.


### PR DESCRIPTION
**Description**

The line separator '\u2028' character was removed (looked out of place).

Highlighted the removed _character_ in the screenshot below for reference:
![removed-character](https://user-images.githubusercontent.com/25162092/90224383-dbb26a00-de0f-11ea-9e6d-f47664c87aa9.png)
