### PR TITLE
Remove unnecessary scrollbar for the sticky navigation

### DIFF
--- a/source/assets/css/components/_navigation.scss
+++ b/source/assets/css/components/_navigation.scss
@@ -2,7 +2,7 @@
   position: sticky;
   top: 0;
   bottom: 0;
-  overflow-y: scroll;
+  overflow-y: auto;
 
   @include sl-breakpoint--large { 
     height: 100vh;


### PR DESCRIPTION
The scrollbar will now appear only for columns needing it.

closes #386