### PR TITLE
Remove redundant word

### DIFF
--- a/source/documentation/values/booleans.html.md.erb
+++ b/source/documentation/values/booleans.html.md.erb
@@ -60,7 +60,7 @@ You can use booleans to choose whether or not to do various things in Sass. The
 
 <%= partial 'code-snippets/example-if' %>
 
-The [`if()` function][] chooses returns one value if its argument is `true` and
+The [`if()` function][] returns one value if its argument is `true` and
 another if its argument is `false`:
 
 [`if()` function]: ../modules#if


### PR DESCRIPTION
The word _chooses_ seems to be redundant in the edited sentence.