### PR TITLE
Resolved typo in argument lists example

### DIFF
--- a/source/code-snippets/_example-mixin-arbitrary-keyword-arguments.html.erb
+++ b/source/code-snippets/_example-mixin-arbitrary-keyword-arguments.html.erb
@@ -3,7 +3,7 @@
 
   @mixin syntax-colors($args...) {
     @debug meta.keywords($args);
-    // (string: #080, comment: #800, variable: $60b)
+    // (string: #080, comment: #800, variable: #60b)
 
     @each $name, $color in meta.keywords($args) {
       pre span.stx-#{$name} {
@@ -22,7 +22,7 @@
 
   @mixin syntax-colors($args...)
     @debug meta.keywords($args)
-    // (string: #080, comment: #800, variable: $60b)
+    // (string: #080, comment: #800, variable: #60b)
 
     @each $name, $color in meta.keywords($args)
       pre span.stx-#{$name}


### PR DESCRIPTION
Resolved the typo inside this "argument lists" example.
(in both the `SASS` and `SCSS` snippets)

Highlighted the changed character in the screenshot below:
Before | After
----------|--------
![before](https://user-images.githubusercontent.com/25162092/95389916-d09e2680-08f4-11eb-8fc7-f5d4bf05b5fc.png)|![after](https://user-images.githubusercontent.com/25162092/95389951-e14e9c80-08f4-11eb-8dd9-b492133958a9.png)

