### PR TITLE
Add missing backtick at the end of inline code

### DIFF
--- a/source/documentation/modules/map.html.md.erb
+++ b/source/documentation/modules/map.html.md.erb
@@ -261,7 +261,7 @@ title: sass:map
             returns: 'map' do %>
   <% heads_up do %>
     In practice, the actual arguments to `map.merge($map1, $keys..., $map2)`
-    are passed as `map.set($map1, $args...). They are described here as `$map1,
+    are passed as `map.set($map1, $args...)`. They are described here as `$map1,
     $keys..., $map2` for explanation purposes only.
   <% end %>
 


### PR DESCRIPTION
Caught this on mobile as layout was broken.