### PR TITLE
Typo: Add missing s to .sass example

### DIFF
--- a/source/documentation/at-rules/import.html.md.erb
+++ b/source/documentation/at-rules/import.html.md.erb
@@ -288,7 +288,7 @@ nested import are still defined globally, though.
     font-family: 'Source Code Pro', Helvetica, Arial
     border-radius: 4px
   ---
-  // style.sas
+  // style.sass
   .theme-sample
     @import theme
   ===


### PR DESCRIPTION
Noticed this little typo.