### PR TITLE
Revert word-break to normal for impl-status titles

### DIFF
--- a/source/assets/css/components/_lists.scss
+++ b/source/assets/css/components/_lists.scss
@@ -126,6 +126,8 @@
   &.impl-status {
     font-size: 0.8em;
     margin-top: -1em;
+    
+    dt { word-break: normal; }
 
     a {
       transition: transform 0.1s;


### PR DESCRIPTION
If the "compatibility" label and browser width are just the wrong one, "break-word" can lead to browsers deciding to line-wrap every "ss" but *just the "ss" from "Dart Sass", "LibSass" and "Ruby Sass", which looks very strange and is quite hard to read.

I've a relatively large screen (34" wide), so I lay out the screen in thirds (so about 1146 wide per window). Using Firefox (FDE 87.0b9), this is apparently exactly the worst possible width for http://bit.ly/ExtendCompound as every single "ss" gets wrapped to the next line:
![Screenshot_2021-03-18 Sass extend](https://user-images.githubusercontent.com/7571158/111641627-a0d94000-87fd-11eb-9372-d621407aa9d1.png)
After:
![Screenshot_2021-03-18 Sass extend(1)](https://user-images.githubusercontent.com/7571158/111641766-bfd7d200-87fd-11eb-8ac0-e0ba119743c0.png)
Disclaimer: I didn't try to build the site, I checked which change should work using the web inspector, then tried to find out where the properties were being defined, then performed the change via github's web UI.
