### PR TITLE
Add documentation of -w shorthand for --watch flag

### DIFF
--- a/source/documentation/cli/dart-sass.html.md.erb
+++ b/source/documentation/cli/dart-sass.html.md.erb
@@ -285,9 +285,9 @@ $ sass --embed-source-map sass/style.scss css.style.css
 
 <% impl_status dart: '1.6.0' %>
 
-This flag acts like the [`--update` flag][], but after the first round
-compilation is done Sass stays open and continues compiling stylesheets whenever
-they or their dependencies change.
+This flag (abbreviated `-w`) acts like the [`--update` flag][], but after the
+first round compilation is done Sass stays open and continues compiling
+stylesheets whenever they or their dependencies change.
 
 [`--update` flag]: #update
 


### PR DESCRIPTION
This is the follow-up documentation change for https://github.com/sass/dart-sass/pull/1276. The diff's a little noisy because of the paragraph reflowing to fit the width limit, but the only new thing in there is the `(abbreviated '-w')` part.