### PR TITLE
Only match Sass files in division migrator glob

### DIFF
--- a/source/documentation/breaking-changes/slash-div.html.md.erb
+++ b/source/documentation/breaking-changes/slash-div.html.md.erb
@@ -109,5 +109,5 @@ use `math.div()` and `list.slash()`.
 
 ```shellsession
 $ npm install -g sass-migrator
-$ sass-migrator division **/*
+$ sass-migrator division **/*.scss
 ```


### PR DESCRIPTION
The migrator doesn't filter out non-Sass files, so it will error if there are any other files there