### PR TITLE
Fix code examples in map and meta modules.

### DIFF
--- a/source/code-snippets/_example-first-class-function.html.erb
+++ b/source/code-snippets/_example-first-class-function.html.erb
@@ -46,7 +46,7 @@
 
   $fonts: Tahoma, Geneva, "Helvetica Neue", Helvetica, Arial, sans-serif
 
-  body
+  .content
     @function contains-helvetica($string)
       @return string.index($string, "Helvetica")
 

--- a/source/code-snippets/_example-first-class-function.html.erb
+++ b/source/code-snippets/_example-first-class-function.html.erb
@@ -52,7 +52,7 @@
 
     font-family: remove-where($fonts, meta.get-function("contains-helvetica"))
   ===
-  body {
+  .content {
     font-family: Tahoma, Geneva, Arial, sans-serif;
   }
 <% end %>

--- a/source/code-snippets/_example-first-class-function.html.erb
+++ b/source/code-snippets/_example-first-class-function.html.erb
@@ -46,13 +46,13 @@
 
   $fonts: Tahoma, Geneva, "Helvetica Neue", Helvetica, Arial, sans-serif
 
-  content
+  body
     @function contains-helvetica($string)
       @return string.index($string, "Helvetica")
 
     font-family: remove-where($fonts, meta.get-function("contains-helvetica"))
   ===
-  content {
+  body {
     font-family: Tahoma, Geneva, Arial, sans-serif;
   }
 <% end %>

--- a/source/documentation/modules/map.html.md.erb
+++ b/source/documentation/modules/map.html.md.erb
@@ -15,10 +15,10 @@ title: sass:map
 
   <% example(autogen_css: false) do %>
     $config: (a: (b: (c: d)));
-    @debug map.get($config, a, b, c)); // d
+    @debug map.get($config, a, b, c); // d
     ===
     $config: (a: (b: (c: d)))
-    @debug map.get($config, a, b, c)) // d
+    @debug map.get($config, a, b, c) // d
   <% end %>
 <% end %>
 


### PR DESCRIPTION
Hi, I believe there is a typo in the first sass:map code example and `content` is not a valid HTML element in the first-class function example of sass:meta.