### PR TITLE
Fix example on the "Slash as Division" page: divide() -> math.div()

### DIFF
--- a/source/documentation/breaking-changes/slash-div.html.md.erb
+++ b/source/documentation/breaking-changes/slash-div.html.md.erb
@@ -83,16 +83,18 @@ create them. You will also be able to pass `"slash"` as the `$separator` to the
 
 <% example do %>
   @use "sass:list";
+  @use "sass:math";
 
   .item3 {
-    $row: list.slash(span divide(6, 2), 7);
+    $row: list.slash(span math.div(6, 2), 7);
     grid-row: $row;
   }
   ===
-  @use "sass:list";
+  @use "sass:list"
+  @use "sass:math"
 
   .item3
-    $row: list.slash(span divide(6, 2), 7)
+    $row: list.slash(span math.div(6, 2), 7)
     grid-row: $row
   ===
   .item3 {


### PR DESCRIPTION
According to my experiments, `divide()` doesn't work, only `math:div()` does.