### PR TITLE
Grammatically updated the docs

### DIFF
--- a/source/documentation/at-rules/function.html.md.erb
+++ b/source/documentation/at-rules/function.html.md.erb
@@ -76,7 +76,7 @@ function's body as the corresponding variables.
 [SassScript expressions]: ../syntax/structure#expressions
 
 <% fun_fact do %>
-  Argument lists can also have trailing commas! This can makes it easier to
+  Argument lists can also have trailing commas! This makes it easier to
   avoid syntax errors when refactoring your stylesheets.
 <% end %>
 


### PR DESCRIPTION
A minor change to the documentation, just corrected a grammar mistake.
I tried to push these changes to the docs branch but I couldn't find the file `sass-site/source/documentation/at-rules/function.html.md.erb` and the docs branch apparently hasn't been updated for more than 7 years.