### PR TITLE
adding optional param description to function-exists

### DIFF
--- a/source/documentation/modules/meta.html.md.erb
+++ b/source/documentation/modules/meta.html.md.erb
@@ -182,13 +182,21 @@ title: sass:meta
 <% end %>
 
 
-<% function 'meta.function-exists($name)',
+<% function 'meta.function-exists($name, $module: null)',
             'function-exists($name)',
             returns: 'boolean' do %>
   Returns whether a function named `$name` is defined, either as a built-in
   function or a user-defined function.
 
+  If `$module` is `null`, this returns the function named `$name` without a
+  namespace (including [global built-in functions][]). Otherwise, `$module` must
+  be a string matching the namespace of a [`@use` rule][] in the current file,
+  in which case this returns the function in that module named `$name`.
+
   <% example(autogen_css: false) do %>
+    @use "sass:math";
+
+    @debug meta.function-exists("div", "math"); // true
     @debug meta.function-exists("scale-color"); // true
     @debug meta.function-exists("add"); // false
 
@@ -197,6 +205,9 @@ title: sass:meta
     }
     @debug meta.function-exists("add"); // true
     ===
+    @use "sass:math"
+
+    @debug meta.function-exists("div", "math")  // true
     @debug meta.function-exists("scale-color")  // true
     @debug meta.function-exists("add")  // false
 
@@ -265,7 +276,7 @@ title: sass:meta
     ===
     @debug meta.global-variable-exists("var1")  // false
 
-    $var1: value 
+    $var1: value
     @debug meta.global-variable-exists("var1")  // true
 
     h1
@@ -280,7 +291,7 @@ title: sass:meta
             'inspect($value)',
             returns: 'unquoted string' do %>
   Returns a string representation of `$value`.
-  
+
   Returns a representation of *any* Sass value, not just those that can be
   represented in CSS. As such, its return value is not guaranteed to be valid
   CSS.
@@ -324,7 +335,7 @@ title: sass:meta
   Returns whether a [mixin][] named `$name` exists.
 
   [mixin]: ../at-rules/mixin
-  
+
   If `$module` is `null`, this returns whether a mixin named `$name` without a
   namespace exists. Otherwise, `$module` must be a string matching the namespace
   of a [`@use` rule][] in the current file, in which case this returns whether
@@ -477,7 +488,7 @@ title: sass:meta
 
   [map function]: map
 
-  <% example(autogen_css: false) do %> 
+  <% example(autogen_css: false) do %>
     @debug meta.type-of(10px); // number
     @debug meta.type-of(10px 20px 30px); // list
     @debug meta.type-of(()); // list
@@ -513,7 +524,7 @@ title: sass:meta
     ===
     @debug meta.variable-exists("var1")  // false
 
-    $var1: value 
+    $var1: value
     @debug meta.variable-exists("var1")  // true
 
     h1


### PR DESCRIPTION
There is a missing parameter on  function `function-exists` parameters
https://sass-lang.com/documentation/modules/meta#function-exists.

Right now it says:
```scss
meta.function-exists($name)
function-exists($name) //=> boolean 
```

And it is suppose to be :
```scss
meta.function-exists($name, $module:null)
function-exists($name) //=> boolean 
```
In order to check for things like:
```scss
@use sass:math;

@debug meta.function-exists("div", "math")
```
