### PR TITLE
Remove incorrectly added SASS code from CSS snippet

### DIFF
--- a/source/documentation/syntax/special-functions.html.md.erb
+++ b/source/documentation/syntax/special-functions.html.md.erb
@@ -134,8 +134,6 @@ Nothing is interpreted as a SassScript expression, with the exception that
     left: calc(50% - #{math.div($width, 2)})
     top: 0
   ===
-  @use "sass:math";
-
   .logo {
     width: 800px;
     position: absolute;


### PR DESCRIPTION
Link: https://sass-lang.com/documentation/syntax/special-functions#calc-clamp-element-progid-and-expression
In the compiled CSS code we can see SASS's import feature but since CSS does not support it, it needs to be removed.

Screenshot: 
![image](https://user-images.githubusercontent.com/20555249/129448166-ca7fefbb-2104-47c0-bff5-cbca6fb716db.png)
