### PR TITLE
Update the doc about dart-sass

### DIFF
--- a/source/dart-sass.html.haml
+++ b/source/dart-sass.html.haml
@@ -46,7 +46,7 @@ introduction: >
         sass: ^#{impl_version(:dart)}
          ```
 
-      3. Run `pub get`.
+      3. Run `dart pub get`.
 
       4. Create a `compile-sass.dart` file like this:
 
@@ -70,7 +70,7 @@ introduction: >
          [Sass's Dart API][sass].
 
          [dart]: https://www.dartlang.org/guides/language/language-tour
-         [sass]: https://www.dartdocs.org/documentation/sass/latest/sass/compile.html
+         [sass]: https://pub.dev/documentation/sass/latest/sass/compileToResult.html
 
   .sl-l-grid__column
     :markdown


### PR DESCRIPTION
- update the Dart API link to go to pub.dev directly and to link to the non-deprecated API
- use the new `dart pub` executable rather than `pub` directly, as it makes it easier when installing dart on Linux distributions that only put the main dart executable on the PATH

Closes https://github.com/sass/sass-site/issues/444 (although the link is not a 404 anymore, because dartdocs.org has implemented the missing redirection)