### PR TITLE
Make the TypeDoc theme resilient against nested child lists

### DIFF
--- a/tool/typedoc-theme.js
+++ b/tool/typedoc-theme.js
@@ -68,7 +68,7 @@ class SassSiteRenderContext extends DefaultThemeRenderContext {
     return navigation;
   }, this);
 
-  // Returns the first child of a JSX node. For some reason, JSX nodes created
+  // Returns the `n`-th child of a JSX node. For some reason, JSX nodes created
   // by TypeDoc can contain nested arrays, so this traverses them.
   _getNthChild = (node, n) => {
     let i = 0;


### PR DESCRIPTION
It's not clear why TypeDoc generates lists of lists for JSX node
children, but it does and we need to handle it.