### PR TITLE
Fix the rendering of compatibility lists

### DIFF
--- a/source/assets/css/components/_lists.scss
+++ b/source/assets/css/components/_lists.scss
@@ -112,6 +112,7 @@
   .compatibility {
     font-weight: 600;
     color: $sl-color--midnight-blue;
+    display: block;
 
     + div { border: 0; }
   }


### PR DESCRIPTION
The compatibility div contains a span in its text, so making it a flex container produces a weird rendering.

Before:
![image](https://user-images.githubusercontent.com/439401/136997753-25a91107-86b9-4d93-a713-f19a694eb2a9.png)

After:
![image](https://user-images.githubusercontent.com/439401/136997839-0b4a21bc-bb75-42a7-86fc-c3a637f55db8.png)
