### PR TITLE
Fix missing hyphen in private members example

### DIFF
--- a/source/documentation/at-rules/use.html.md.erb
+++ b/source/documentation/at-rules/use.html.md.erb
@@ -265,7 +265,7 @@ them!
   $-radius: 3px
 
   @mixin rounded
-    border-radius: $radius
+    border-radius: $-radius
   ---
   // style.sass
   @use "src/corners"


### PR DESCRIPTION
Tiny fix. The variable referenced inside of the mixin of the Sass private members code example does not match the variable assigned above it or referenced below it. 