### PR TITLE
docs: correct mixin name

### DIFF
--- a/source/documentation/at-rules/forward.html.md.erb
+++ b/source/documentation/at-rules/forward.html.md.erb
@@ -151,7 +151,7 @@ variables (including the `$`).
   }
 
   @mixin list-horizontal {
-    @include reset;
+    @include list-rest;
 
     li {
       display: inline-block;
@@ -175,7 +175,7 @@ variables (including the `$`).
 
 
   @mixin list-horizontal
-    @include reset
+    @include list-rest
 
     li
       display: inline-block


### PR DESCRIPTION
`@reset` mixin is not defined in this example, but `@list-rest` is.