### PR TITLE
Fix Sass interpolation example to match the SCSS one and its output

### DIFF
--- a/source/documentation/interpolation.html.md.erb
+++ b/source/documentation/interpolation.html.md.erb
@@ -39,7 +39,7 @@ introduction: >
 
 
 
-  @include corner-icon("mail", top, right)
+  @include corner-icon("mail", top, left)
 <% end %>
 
 ## In SassScript


### PR DESCRIPTION
In the [Interpolation docs](https://sass-lang.com/documentation/interpolation), the first example is supposed to give this output :

```css
.icon-mail {
  background-image: url("/icons/mail.svg");
  position: absolute;
  top: 0;
  left: 0;
}
```

The SCSS example is fine and produces the expected output:

```scss
@mixin corner-icon($name, $top-or-bottom, $left-or-right) {
  .icon-#{$name} {
    background-image: url("/icons/#{$name}.svg");
    position: absolute;
    #{$top-or-bottom}: 0;
    #{$left-or-right}: 0;
  }
}

@include corner-icon("mail", top, left);
```

However, the Sass example has a small issue:
```sass
@mixin corner-icon($name, $top-or-bottom, $left-or-right)
  .icon-#{$name}
    background-image: url("/icons/#{$name}.svg")
    position: absolute
    #{$top-or-bottom}: 0
    #{$left-or-right}: 0



@include corner-icon("mail", top, right)
```

As you can see, the last parameter to the `corner-icon` call should be `left`.