### PR TITLE
Fix list.slash documentation example typo

### DIFF
--- a/source/documentation/modules/list.html.md.erb
+++ b/source/documentation/modules/list.html.md.erb
@@ -213,9 +213,9 @@ title: sass:list
   <% end %>
 
   <% example(autogen_css: false) do %>
-    @debug list.slash(1px, 50px, 100px); // 10px / 50px / 100px
+    @debug list.slash(1px, 50px, 100px); // 1px / 50px / 100px
     ===
-    @debug list.slash(1px, 50px, 100px)  // 10px / 50px / 100px
+    @debug list.slash(1px, 50px, 100px)  // 1px / 50px / 100px
   <% end %>
 <% end %>
 


### PR DESCRIPTION
Hi! Just a small patch to fix a typo that caused me to think for a couple of seconds about why 1px became 10px :)