### PR TITLE
Revert "Disable word wrapping for `p code` (#281)" to fix #576

### DIFF
--- a/source/assets/css/visual-design/_typography.scss
+++ b/source/assets/css/visual-design/_typography.scss
@@ -179,8 +179,7 @@ code {
   font-size: ($sl-font-size--small / $sl-font-size--medium) * 1em;
   line-height: 1;
 
-  nav &,
-  p & { white-space: nowrap; }
+  nav & { white-space: nowrap; }
 }
 
 pre {

--- a/source/assets/css/visual-design/_typography.scss
+++ b/source/assets/css/visual-design/_typography.scss
@@ -148,7 +148,7 @@ h3,
 thead th { font-family: $sl-font-family--display; }
 
 h2,
-caption, {
+caption {
   font-size: $sl-font-size--x-large;
 
   @include sl-breakpoint--medium { font-size: $sl-font-size--xx-large; }

--- a/source/assets/css/visual-design/_typography.scss
+++ b/source/assets/css/visual-design/_typography.scss
@@ -180,6 +180,9 @@ code {
   line-height: 1;
 
   nav & { white-space: nowrap; }
+  p & {
+    @include sl-breakpoint--x-large { white-space: nowrap; }
+  }
 }
 
 pre {


### PR DESCRIPTION
This reverts commit 77311c93f99c91ef8f450c269fd72a8c7456a430.

Fixes #576 by allowing word-wrap in code snippets, as commented [here](https://github.com/sass/sass-site/issues/576#issuecomment-1127088521).

### Before
![before](https://user-images.githubusercontent.com/610974/172259793-d049ca95-4ece-4ea0-8e82-c240bac28db7.png)
### After
![after](https://user-images.githubusercontent.com/610974/172259786-432ef434-4a1f-46e9-ae88-bef25f80cddd.png)

