### PR TITLE
#638 fix link to Ghostlab

### DIFF
--- a/source/install.html.haml
+++ b/source/install.html.haml
@@ -22,8 +22,8 @@ no_container: true
         Mac
 
       %li
-        = link_to 'Ghostlab', 'http://www.vanamco.com/ghostlab/'
-        (Paid)
+        = link_to 'Ghostlab', 'https://www.vanamco.com/'
+        (Free)
         Mac
         Windows
 

--- a/source/install.html.haml
+++ b/source/install.html.haml
@@ -22,12 +22,6 @@ no_container: true
         Mac
 
       %li
-        = link_to 'Ghostlab', 'https://www.vanamco.com/'
-        (Free)
-        Mac
-        Windows
-
-      %li
         = link_to 'Hammer', 'http://hammerformac.com/'
         (Paid)
         Mac


### PR DESCRIPTION
Fixes #638

Fixes broken url and changes Paid to Free in the description.

Can someone still vouch for this Ghostlab software? Its current page looks kinda sketchy.