### PR TITLE
Update the CNAME parameter for our GitHub Pages deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,5 +48,5 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./build
-        cname: gh-pages.sass-lang.com
+        cname: sass-lang.com
         allow_empty_commit: true


### PR DESCRIPTION
Now that we're serving primarily from GitHub pages, we should deploy
to the full website and not the subdomain.