### PR TITLE
HWB support was introduced in 1.28.0, not in 1.27.0

### DIFF
--- a/source/documentation/modules/color.html.md.erb
+++ b/source/documentation/modules/color.html.md.erb
@@ -12,7 +12,7 @@ color.adjust($color,
   $alpha: null)
 SIGNATURE
 %>
-  <% impl_status dart: '1.27.0', libsass: false, ruby: false, feature: "$whiteness and $blackness" %>
+  <% impl_status dart: '1.28.0', libsass: false, ruby: false, feature: "$whiteness and $blackness" %>
 
   Increases or decreases one or more properties of `$color` by fixed amounts.
 
@@ -125,7 +125,7 @@ SIGNATURE
 
 
 <% function 'color.blackness($color)', returns: 'number' do %>
-  <% impl_status dart: '1.27.0', libsass: false, ruby: false %>
+  <% impl_status dart: '1.28.0', libsass: false, ruby: false %>
 
   Returns the [HWB][] blackness of `$color` as a number between `0%` and `100%`.
 
@@ -187,7 +187,7 @@ color.change($color,
   $alpha: null)
 SIGNATURE
 %>
-  <% impl_status dart: '1.27.0', libsass: false, ruby: false, feature: "$whiteness and $blackness" %>
+  <% impl_status dart: '1.28.0', libsass: false, ruby: false, feature: "$whiteness and $blackness" %>
 
   Sets one or more properties of a color to new values.
 
@@ -440,7 +440,7 @@ SIGNATURE
 <% function 'color.hwb($hue $whiteness $blackness)',
             'color.hwb($hue $whiteness $blackness / $alpha)',
             'color.hwb($hue, $whiteness, $blackness, $alpha: 1)', returns: 'color' do %>
-  <% impl_status dart: '1.27.0', libsass: false, ruby: false %>
+  <% impl_status dart: '1.28.0', libsass: false, ruby: false %>
 
   Returns a color with the given [hue, whiteness, and blackness][] and the given
   alpha channel.
@@ -786,7 +786,7 @@ color.scale($color,
   $alpha: null)
 SIGNATURE
 %>
-  <% impl_status dart: '1.27.0', libsass: false, ruby: false, feature: "$whiteness and $blackness" %>
+  <% impl_status dart: '1.28.0', libsass: false, ruby: false, feature: "$whiteness and $blackness" %>
 
 Fluidly scales one or more properties of `$color`.
 
@@ -869,7 +869,7 @@ Fluidly scales one or more properties of `$color`.
 
 
 <% function 'color.whiteness($color)', returns: 'number' do %>
-  <% impl_status dart: '1.27.0', libsass: false, ruby: false %>
+  <% impl_status dart: '1.28.0', libsass: false, ruby: false %>
 
   Returns the [HWB][] whiteness of `$color` as a number between `0%` and `100%`.
 


### PR DESCRIPTION
As per https://github.com/sass/dart-sass/pull/1129, HWB support was introduced in 1.28.0, not in 1.27.0.

- Code change: https://github.com/sass/dart-sass/pull/1129
- Follows up https://github.com/sass/sass-site/pull/493

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)