### PR TITLE
fix: Add More Info on Equality Operators page

### DIFF
--- a/source/documentation/operators/equality.html.md.erb
+++ b/source/documentation/operators/equality.html.md.erb
@@ -18,10 +18,11 @@ they're the same type *and* the same value, which means different things for
 different types:
 
 [expressions]: ../syntax/structure#expressions
+[deprecated]: /blog/libsass-is-deprecated
 
 * [Numbers][] are equal if they have the same value *and* the same units, or if
   their values are equal when their units are converted between one another.
-  If no unit is declared, only values are compared.
+  If no unit is declared, the result will be different depending on what version you are using. (If you are using LibSass, please note that LibSass is [deprecated][].)
 * [Strings][] are unusual in that [unquoted][] and [quoted][] strings with the
   same contents are considered equal.
 * [Colors][] are equal if they have the same red, green, blue, and alpha values.
@@ -51,7 +52,7 @@ different types:
 <% example(autogen_css: false) do %>
   @debug 1px == 1px; // true
   @debug 1px != 1em; // true
-  @debug 1 != 1px; // false
+  @debug 1 != 1px; // true, false if you are using LibSass under v3.6.5
   @debug 96px == 1in; // true
 
   @debug "Helvetica" == Helvetica; // true

--- a/source/documentation/operators/equality.html.md.erb
+++ b/source/documentation/operators/equality.html.md.erb
@@ -21,6 +21,7 @@ different types:
 
 * [Numbers][] are equal if they have the same value *and* the same units, or if
   their values are equal when their units are converted between one another.
+  If no unit is declared, only values are compared.
 * [Strings][] are unusual in that [unquoted][] and [quoted][] strings with the
   same contents are considered equal.
 * [Colors][] are equal if they have the same red, green, blue, and alpha values.
@@ -50,7 +51,7 @@ different types:
 <% example(autogen_css: false) do %>
   @debug 1px == 1px; // true
   @debug 1px != 1em; // true
-  @debug 1 != 1px; // true
+  @debug 1 != 1px; // false
   @debug 96px == 1in; // true
 
   @debug "Helvetica" == Helvetica; // true


### PR DESCRIPTION
# Issue

Resolves: #676

# Summery

`@debug 1 != 1px;` is `false`, and `@debug 1 != 1rem;` is also `false`.

So I've added some and fixed comment.