### PR TITLE
Docs:  Edit [numeric.html.md.erb]

### DIFF
--- a/source/documentation/operators/numeric.html.md.erb
+++ b/source/documentation/operators/numeric.html.md.erb
@@ -23,7 +23,7 @@ introduction: >
 <% example(autogen_css: false) do %>
   @debug 10s + 15s; // 25s
   @debug 1in - 10px; // 0.8958333333in
-  @debug 5px * 3px; // 15px*px
+  @debug 5px * 3px; // error
   @debug 1in % 9px; // 0.0625in
   ===
   @debug 10s + 15s  // 25s


### PR DESCRIPTION
Document is not correct, 'Numeric Operators' part

(https://sass-lang.com/documentation/operators/numeric) In the code block below, 
it says `@debug 5px * 3px; // 15px*px` but It's actually printed 'error' message.

Resolves: #675