### PR TITLE
Fix broken link

### DIFF
--- a/data/documentation.yml
+++ b/data/documentation.yml
@@ -65,7 +65,7 @@ toc:
   - Invalid Combinators: /documentation/breaking-changes/bogus-combinators
   - Media Queries Level 4: /documentation/breaking-changes/media-logic
   - <code>/</code> as Division: /documentation/breaking-changes/slash-div
-  - Color Units: /documentation/breaking-changes/color-units
+  - Function Units: /documentation/breaking-changes/function-units
   - <code>-moz-document</code>: /documentation/breaking-changes/moz-document
   - Extending Compound Selectors: /documentation/breaking-changes/extend-compound
   - CSS Variable Syntax: /documentation/breaking-changes/css-vars


### PR DESCRIPTION
In the docs I noticed the sidebar link `Breaking Changes > Color Units` doesn't work.  I poked around and saw there's a "Function Units" page that doesn't have a sidebar link.  This PR updates the "Color Units" sidebar link to point to the "Function Units" page.  I haven't tested this change locally because I'm not great with Ruby, but I did triple-check my spelling.  Let me know if this needs anything else.  Thanks!

<img width="1009" alt="sass-lang-docs-sidebar" src="https://user-images.githubusercontent.com/6802815/211485181-f053fd6e-2736-4130-bb64-718964706457.png">

<img width="353" alt="function-units-page" src="https://user-images.githubusercontent.com/6802815/211485684-565f8687-f442-46f9-84a8-49b5e5b55f4d.png">
