### PR TITLE
#693 fixed sass syntax documentation

### DIFF
--- a/source/documentation/syntax.html.md.erb
+++ b/source/documentation/syntax.html.md.erb
@@ -41,7 +41,7 @@ SCSS looks like this:
 The indented syntax was Sass's original syntax, and so it uses the file
 extension `.sass`. Because of this extension, it's sometimes just called "Sass".
 The indented syntax supports all the same features as SCSS, but it uses
-indentation instead of curly braces and semicolons to describe the format of the
+indentation instead of curly braces and it does not use semicolons to describe the format of the
 document.
 
 In general, any time you'd write curly braces in CSS or SCSS, you can just


### PR DESCRIPTION
Error in the documentation regarding usage of semicolon in sass syntax documentation is fixed.