### PR TITLE
Bump versions of GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,21 +6,22 @@ on:
   pull_request:
 
 env:
-  RUBY_VERSION: 2.5.3
-  NODE_VERSION: 16
+  RUBY_VERSION: 2.7.7
+  NODE_VERSION: 18
 
 jobs:
   unit_tests:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
       with:
         node-version: ${{ env.NODE_VERSION }}
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ env.RUBY_VERSION }}
+        bundler: 1.17.3
         bundler-cache: true
     - run: bundle exec rake test
 
@@ -33,8 +34,8 @@ jobs:
         github.repository == 'sass/sass-site'
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
       with:
         node-version: ${{ env.NODE_VERSION }}
     - uses: ruby/setup-ruby@v1
@@ -44,7 +45,7 @@ jobs:
     - run: bundle exec rake build
 
     - name: Deploy
-      uses: peaceiris/actions-gh-pages@068dc23d9710f1ba62e86896f84735d869951305 # v3.8.0
+      uses: peaceiris/actions-gh-pages@bd8c6b06eba6b3d25d72b7a1767993c0aeee42e7 # v3.9.2
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./build

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
-ruby "2.5.3"
+ruby "2.7.7"
 
 gem "builder",                "~> 3.2.2"
 gem "html-proofer",           "~> 3.13"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -217,7 +217,7 @@ DEPENDENCIES
   wdm (~> 0.1.1)
 
 RUBY VERSION
-   ruby 2.5.3p105
+   ruby 2.7.7
 
 BUNDLED WITH
-   1.16.6
+   1.17.3


### PR DESCRIPTION
This PR bumps versions in GitHub workflow scripts, thus avoiding deprecation warnings.