### PR TITLE
Document --fatal-deprecation

### DIFF
--- a/source/documentation/breaking-changes.html.md.erb
+++ b/source/documentation/breaking-changes.html.md.erb
@@ -40,3 +40,75 @@ These breaking changes are coming soon or have recently been released:
 
 * [The syntax for CSS custom property values changed](breaking-changes/css-vars)
   in Dart Sass 1.0.0, LibSass 3.5.0, and Ruby Sass 3.5.0.
+
+## Early Opt-In
+
+<% impl_status dart: '1.59.0', libsass: false, ruby: false %>
+
+Users who wish to treat certain deprecation warnings as errors immediately can
+do so with the `--fatal-deprecation` command line option. For example,
+`--fatal-deprecation=slash-div` will treat all deprecation warnings for
+`/`-as-division as errors.
+
+<table style="width:100%">
+<thead>
+  <tr style="text-align: left">
+    <th>ID</th>
+    <th>Version</th>
+    <th>Description</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td><code>call-string</code></td>
+    <td>0.0.0</td>
+    <td>Passing a string directly to <code>meta.call()</code>.</td>
+  </tr>
+  <tr>
+    <td><code>elseif</code></td>
+    <td>1.3.2</td>
+    <td>Using <code>@elseif</code> instead of <code>@else if</code>.</td>
+  </tr>
+  <tr>
+    <td><a href="breaking-changes/moz-document"><code>moz-document</code></a></td>
+    <td>1.7.2</td>
+    <td>Using <code>@-moz-document</code> (except for the empty url prefix hack).</td>
+  </tr>
+  <tr>
+    <td><code>new-global</code></td>
+    <td>1.17.2</td>
+    <td>Declaring new variables with <code>!global</code>.</td>
+  </tr>
+  <tr>
+    <td><code>color-module-compat</code></td>
+    <td>1.23.0</td>
+    <td>Using color module functions in place of plain CSS functions.</td>
+  </tr>
+  <tr>
+    <td><a href="breaking-changes/slash-div"><code>slash-div</code></a></td>
+    <td>1.33.0</td>
+    <td>Using the <code>/</code> operator for division.</td>
+  </tr>
+  <tr>
+    <td><a href="breaking-changes/bogus-combinators"><code>bogus-combinators</code></a></td>
+    <td>1.54.0</td>
+    <td>Leading, trailing, and repeated combinators.</td>
+  </tr>
+  <tr>
+    <td><a href="breaking-changes/strict-unary"><code>strict-unary</code></a></td>
+    <td>1.55.0</td>
+    <td>Ambiguous <code>+</code> and <code>-</code> operators.</td>
+  </tr>
+  <tr>
+    <td><a href="breaking-changes/function-units"><code>function-units</code></a></td>
+    <td>1.56.0</td>
+    <td>Passing invalid units to built-in functions.</td>
+  </tr>
+</tbody>
+</table>
+
+Alternatively, you can pass a Dart Sass version to `--fatal-deprecation` to
+treat all deprecations that were present in that version as errors. For
+example, `--fatal-deprecation=1.33.0` would treat all deprecations in the
+table above up to and including `slash-div` as errors, but leave any newer
+deprecations as warnings.


### PR DESCRIPTION
For future reference, here is the Markdown-equivalent of the table below, so that we can replace the HTML table with it once we migrate to Eleventy

```
| ID                    | Version | Description                                                    |
|-----------------------|---------|----------------------------------------------------------------|
| `call-string`         | 0.0.0   | Passing a string directly to `meta.call()`                     |
| `elseif`              | 1.3.2   | Using `@elseif` instead of `@else if`                          |
| [`moz-document`]      | 1.7.2   | Using `@-moz-document` (except for the empty url prefix hack). |
| `new-global`          | 1.17.2  | Declaring new variables with `!global`.                        |
| `color-module-compat` | 1.23.0  | Using color module functions in place of plain CSS functions.  |
| [`slash-div`]         | 1.33.0  | Using the `/` operator for division.                           |
| [`bogus-combinators`] | 1.54.0  | Leading, trailing, and repeated combinators.                   |
| [`strict-unary`]      | 1.55.0  | Ambiguous `+` and `-` operators.                               |
| [`function-units`]    | 1.56.0  | Passing invalid units to built-in functions.                   |

[`moz-document`]: breaking-changes/moz-document
[`slash-div`]: breaking-changes/slash-div
[`bogus-combinators`]: breaking-changes/bogus-combinators
[`strict-unary`]: breaking-changes/strict-unary
[`function-units`]: breaking-changes/function-units
```