### PR TITLE
Separate out building and updating the shadow repo

### DIFF
--- a/.github/workflows/shadow-repo-build.yml
+++ b/.github/workflows/shadow-repo-build.yml
@@ -1,0 +1,40 @@
+name: Shadow Repo
+
+on:
+  push:
+  pull_request:
+    types: [opened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci
+      - run: npm run build-prod
+      - run: tar cf site.tar _site
+      - uses: actions/upload-artifact@v2
+        with:
+          name: site
+          path: site.tar
+
+  diff-link:
+    name: Comment
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.event.action == 'opened'
+    steps:
+      - uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{ github.event.number }}
+          body: |
+            View diff of compiled files (may take a few minutes): https://github.com/${{ vars.SHADOW_OWNER }}/${{ vars.SHADOW_REPO }}/compare/${{ github.event.pull_request.base.ref }}..${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/shadow-repo-update.yml
+++ b/.github/workflows/shadow-repo-update.yml
@@ -1,21 +1,21 @@
-name: Sync with shadow repo
+name: Shadow Repo / Update
 
 on:
-  push:
   create:
   delete:
-  pull_request:
-    types: [opened]
+  workflow_run:
+    workflows: Shadow Repo
+    types: [completed]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:
-  sync-branch:
-    name: Create/delete shadow branch
+  create:
+    name: Create Branch
     runs-on: ubuntu-latest
-    if: github.event.ref_type == 'branch'
+    if: github.event.ref_type == 'branch' && github.event_name == 'create'
     steps:
       - name: Clone shadow repo
         uses: actions/checkout@v3
@@ -24,24 +24,27 @@ jobs:
           token: ${{ secrets.SASS_SITE_TOKEN }}
           ref: main
       - name: Create branch on shadow repo
-        if: github.event_name == 'create'
         run: git push origin main:${{ github.event.ref }}
+
+  delete:
+    name: Delete Branch
+    runs-on: ubuntu-latest
+    if: github.event.ref_type == 'branch' && github.event_name == 'delete'
+    steps:
+      - name: Clone shadow repo
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ vars.SHADOW_OWNER }}/${{ vars.SHADOW_REPO }}
+          token: ${{ secrets.SASS_SITE_TOKEN }}
+          ref: main
       - name: Delete branch on shadow repo
-        if: github.event_name == 'delete'
         run: git push origin --delete ${{ github.event.ref }}
 
-  push-branch:
-    name: Push to shadow branch
+  push:
+    name: Push
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
+    if: github.event_name == 'workflow_run'
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version-file: .nvmrc
-          cache: npm
-      - run: npm ci
-      - run: npm run build-prod
       - name: Clone shadow repo
         uses: actions/checkout@v3
         with:
@@ -49,11 +52,16 @@ jobs:
           token: ${{ secrets.SASS_SITE_TOKEN }}
           ref: ${{ github.ref_name }}
           path: shadow-repo
+      - name: Download built site
+        uses: dawidd6/action-download-artifact@v2.27.0
+        with:
+          name: site
+          run_id: ${{ github.event.workflow_run.id }}
       - name: Update shadow repo files
         run: |
-          cd shadow-repo
-          rm -rf ./*
-          cp -rT ../_site .
+          rm -rf shadow_repo/*
+          tar xf site.tar
+          cp -rT _site shadow_repo
       - uses: EndBug/add-and-commit@v9
         with:
           cwd: shadow-repo
@@ -61,14 +69,3 @@ jobs:
           author_email: sass.bot.beep.boop@gmail.com
           message: Update from https://github.com/${{ github.repository }}/commit/${{ github.sha }}
           commit: --allow-empty
-
-  diff-link:
-    name: Create comment to diff link
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.event.action == 'opened'
-    steps:
-      - uses: peter-evans/create-or-update-comment@v2
-        with:
-          issue-number: ${{ github.event.number }}
-          body: |
-            View diff of compiled files (may take a few minutes): https://github.com/${{ vars.SHADOW_OWNER }}/${{ vars.SHADOW_REPO }}/compare/${{ github.event.pull_request.base.ref }}..${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
We can't update it directly from PRs because external PRs are run in
an untrusted context without secrets access. Instead, as suggested by
[this article], we build the site in an untrusted workflow and then
push it in a trusted workflow that has no access to the PR contents
itself.

[this article]: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/,