### PR TITLE
fix(docs): correct default import example about default export

### DIFF
--- a/source/documentation/breaking-changes/default-export.md
+++ b/source/documentation/breaking-changes/default-export.md
@@ -35,4 +35,4 @@ import * as sass from 'sass'; // Do this
 Until Dart Sass 2.0.0, we will continue to support users loading Sass's default
 export. The first time any properties on the default export are accessed, it
 will emit a deprecation warning to `console.error()`. To avoid this error, use
-`import * as sass form 'sass'` instead.
+`import * as sass from 'sass'` instead.


### PR DESCRIPTION
I am applying a subtle typo correction to the `breaking-changes/default-export.md` document in this pull request.
I found this typo while translating this document for the translated version of the website I am working on.

@nex3 