### PR TITLE
Compress Sass playground URL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
+        "pako": "^2.1.0",
         "seedrandom": "^3.0.5"
       },
       "devDependencies": {
@@ -33,6 +34,7 @@
         "@types/markdown-it-attrs": "^4.1.0",
         "@types/markdown-it-footnote": "^3.0.0",
         "@types/node": "^16",
+        "@types/pako": "^2.0.0",
         "@types/prismjs": "^1.26.0",
         "@types/seedrandom": "^3.0.5",
         "@types/semver": "^7.5.0",
@@ -2828,6 +2830,12 @@
       "version": "2.4.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/pako": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.0.tgz",
+      "integrity": "sha512-10+iaz93qR5WYxTo+PMifD5TSxiOtdRaxBf7INGGXMQgTCu8Z/7GYWYFUOS3q/G0nE5boj1r4FEB+WSy7s5gbA==",
+      "dev": true
     },
     "node_modules/@types/prismjs": {
       "version": "1.26.0",
@@ -7686,6 +7694,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "dev": true,
@@ -11986,6 +11999,12 @@
       "version": "2.4.1",
       "dev": true
     },
+    "@types/pako": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.0.tgz",
+      "integrity": "sha512-10+iaz93qR5WYxTo+PMifD5TSxiOtdRaxBf7INGGXMQgTCu8Z/7GYWYFUOS3q/G0nE5boj1r4FEB+WSy7s5gbA==",
+      "dev": true
+    },
     "@types/prismjs": {
       "version": "1.26.0",
       "dev": true
@@ -15012,6 +15031,11 @@
     "p-try": {
       "version": "2.2.0",
       "dev": true
+    },
+    "pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
     },
     "parent-module": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@types/markdown-it-attrs": "^4.1.0",
     "@types/markdown-it-footnote": "^3.0.0",
     "@types/node": "^16",
+    "@types/pako": "^2.0.0",
     "@types/prismjs": "^1.26.0",
     "@types/seedrandom": "^3.0.5",
     "@types/semver": "^7.5.0",
@@ -99,6 +100,7 @@
     "typogr": "^0.6.8"
   },
   "dependencies": {
+    "pako": "^2.1.0",
     "seedrandom": "^3.0.5"
   }
 }

--- a/source/assets/js/playground.ts
+++ b/source/assets/js/playground.ts
@@ -42,7 +42,7 @@ function setupPlayground() {
         debouncedUpdateCSS();
       }
       if (['inputFormat', 'outputFormat', 'inputValue'].includes(prop)) {
-        updateURL();
+        debounce(updateURL, 200);
       }
       return set;
     },

--- a/source/assets/js/playground.ts
+++ b/source/assets/js/playground.ts
@@ -42,7 +42,7 @@ function setupPlayground() {
         debouncedUpdateCSS();
       }
       if (['inputFormat', 'outputFormat', 'inputValue'].includes(prop)) {
-        debounce(updateURL, 200);
+        debounceUpdateURL();
       }
       return set;
     },
@@ -233,6 +233,8 @@ function setupPlayground() {
       return {error};
     }
   }
+
+  const debounceUpdateURL = debounce(updateURL, 200);
 
   function updateURL() {
     const hash = stateToBase64(playgroundState);

--- a/source/assets/js/playground/utils.ts
+++ b/source/assets/js/playground/utils.ts
@@ -55,8 +55,8 @@ export function base64ToState(input: string): Partial<PlaygroundState> {
   try {
     decoded = inflateFromBase64(input);
   } catch (error) {
-    // Assume the originally decoded URL was valid if it could not be inflated
-    // for backwards compatibility.
+    // For backwards compatibility, decode the URL using the old decoding
+    // strategy if the URL could not be inflated.
     try {
       decoded = decodeURIComponent(atob(input));
     } catch (error) {

--- a/source/assets/js/playground/utils.ts
+++ b/source/assets/js/playground/utils.ts
@@ -24,24 +24,44 @@ export function stateToBase64(state: PlaygroundState): string {
   const inputFormatChar = state.inputFormat === 'scss' ? 1 : 0;
   const outputFormatChar = state.outputFormat === 'expanded' ? 1 : 0;
   const persistedState = `${inputFormatChar}${outputFormatChar}${state.inputValue}`;
-  const compressedState = new TextDecoder().decode(deflate(persistedState));
-  return btoa(encodeURIComponent(compressedState));
+  return deflateToBase64(persistedState);
 }
 
-export function base64ToState(string: string): Partial<PlaygroundState> {
+/** Compresses `input` and returns a base64 string of the compressed bytes. */
+function deflateToBase64(input: string): string {
+  const deflated = deflate(input);
+  // btoa() input can't contain multi-byte characters, so it must be manually
+  // decoded into an ASCII string. TextDecoder can't take multi-byte characters,
+  // and encodeURIComponent doesn't escape all characters.
+  return btoa(String.fromCharCode(...deflated));
+}
+
+/** Decompresses a base64 `input` into the original string. */
+function inflateFromBase64(input: string): string {
+  const base64 = atob(input);
+  const deflated = new Uint8Array(base64.length);
+  // Manually encode the inflated string because it was manually decoded without
+  // TextDecode. TextEncoder would generate a different representation for the
+  // given input.
+  for (let i = 0; i < base64.length; i++) {
+    deflated[i] = base64.charCodeAt(i);
+  }
+  return inflate(deflated, {to: 'string'});
+}
+
+export function base64ToState(input: string): Partial<PlaygroundState> {
   const state: Partial<PlaygroundState> = {};
   let decoded: string;
   try {
-    decoded = decodeURIComponent(atob(string));
-  } catch (error) {
-    return {};
-  }
-  try {
-    const compressedState = new TextEncoder().encode(decoded);
-    decoded = inflate(compressedState, {to: 'string'});
+    decoded = inflateFromBase64(input);
   } catch (error) {
     // Assume the originally decoded URL was valid if it could not be inflated
     // for backwards compatibility.
+    try {
+      decoded = decodeURIComponent(atob(input));
+    } catch (error) {
+      return {};
+    }
   }
 
   if (!/\d\d.*/.test(decoded)) return {};


### PR DESCRIPTION
Uses 'pako' to compress the playground state into a shorter base64 representation. Also decompresses the URL back into the playground when loading the first time.

If the output can't be decompressed, it'll be assumed to be already decompressed for backwards compatibility and shown as-is.

Measured impact using `_playground.scss`. The file has 7k characters and resulted in a 14k-long URL. Now it compresses down to 2.6k.