### PR TITLE
fix(documentation): fix syntax.specialFunction typo

### DIFF
--- a/source/documentation/syntax/special-functions.md
+++ b/source/documentation/syntax/special-functions.md
@@ -141,5 +141,5 @@ Nothing is interpreted as a SassScript expression, with the exception that
   $logo-element: logo-bg
 
   .logo
-    background: element(##{$logo-element})
+    background: element(#{$logo-element})
 {% endcodeExample %}


### PR DESCRIPTION
* Remove an extra `#`, fixing the sample code

# How to review?
* [Running locally](https://github.com/sass/sass-site/blob/main/CONTRIBUTING.md#running-locally), checking that all is working fine
* Check in your preferred editor (online or not), that it's parsed to CSS
![image](https://github.com/sass/sass-site/assets/39351487/36e3a8df-388a-471c-be19-eb6d704399ea)

