### PR TITLE
feat(layout): remove "Black Lives Matter" strip

### DIFF
--- a/source/_data/alerts.yml
+++ b/source/_data/alerts.yml
@@ -1,4 +1,1 @@
-- heading: Black Lives Matter
-  body: >
-    Sass stands with the protesters against police violence. We encourage our
-    users to **get in the streets and join them if you can**.
+#


### PR DESCRIPTION
Hey!

This PR removes the "Black Lives Matter" strip off the SASS website. Maybe instead of encouraging users to "get in the streets" we could make room for something more software-related, who knows?

Thanks!