### PR TITLE
Add import math lib example code

### DIFF
--- a/source/documentation/modules/math.md
+++ b/source/documentation/modules/math.md
@@ -4,6 +4,12 @@ title: sass:math
 
 {% render 'doc_snippets/built-in-module-status' %}
 
+## Import math module
+
+{% codeExample 'import math', false %}
+  @use "sass:math";
+{% endcodeExample %}
+
 ## Variables
 
 {% function 'math.$e' %}


### PR DESCRIPTION
I never find how i need to import modules in scss anywhere in the docs

So propose we add it at the top of docs page

Maybe this can be added to other module pages as well in separate PR's