### PR TITLE
Disable the typography replacements in the markdown engine

### DIFF
--- a/source/helpers/engines.ts
+++ b/source/helpers/engines.ts
@@ -19,7 +19,7 @@ import {renderPermalink} from './components/anchors';
  */
 export const markdownEngine = markdown({
   html: true,
-  typographer: true,
+  typographer: false,
 })
   .use(markdownDefList)
   .use(markdownItAttrs)


### PR DESCRIPTION
Closes https://github.com/sass/sass-site/issues/832

See https://github.com/markdown-it/markdown-it/blob/master/lib/rules_core/replacements.js for the list of replacements this feature is doing.
the documentation does not rely on any of them currently.