### PR TITLE
Reduce the size of the Black Lives Matter banner

### DIFF
--- a/source/_data/alerts.yml
+++ b/source/_data/alerts.yml
@@ -1,4 +1,1 @@
-- heading: Black Lives Matter
-  body: >
-    Sass stands with the protesters against police violence. We encourage our
-    users to **get in the streets and join them if you can**.
+- body: '**Black Lives Matter**'

--- a/source/_data/alerts.yml
+++ b/source/_data/alerts.yml
@@ -1,1 +1,2 @@
 - body: '**Black Lives Matter**'
+  color: black

--- a/source/_includes/header.liquid
+++ b/source/_includes/header.liquid
@@ -4,7 +4,10 @@
   itemscope="itemscope"
   role="banner">
   {% for alert in alerts | default: [] %}
-    <div class="sl-c-alert">
+    {% if alert.color %}
+      {% assign style = "--sl-background--alert: " | append: alert.color %}
+    {% endif %}
+    <div class="sl-c-alert" style="{{ style }}">
       <div class="sl-l-container">
         {% if alert.heading %}
           <h2 class="sl-c-alert-title">{{ alert.heading }}</h2>

--- a/source/_includes/header.liquid
+++ b/source/_includes/header.liquid
@@ -4,9 +4,11 @@
   itemscope="itemscope"
   role="banner">
   {% for alert in alerts | default: [] %}
-    <div class="sl-c-alert sl-c-alert--special">
+    <div class="sl-c-alert">
       <div class="sl-l-container">
-        <h2 class="sl-c-alert-title">{{ alert.heading }}</h2>
+        {% if alert.heading %}
+          <h2 class="sl-c-alert-title">{{ alert.heading }}</h2>
+        {% endif %}
         {{ alert.body | markdown }}
       </div>
     </div>

--- a/source/assets/sass/components/_alerts.scss
+++ b/source/assets/sass/components/_alerts.scss
@@ -2,7 +2,7 @@
 @use '../config/color/brand';
 
 .sl-c-alert {
-  background: var(--sl-background--alert, black);
+  background: var(--sl-background--alert, var(--sl-color--highlight));
   color: var(--sl-color--white);
   font-size: var(--sl-font-size--small);
   padding-bottom: var(--sl-padding-block--alert, var(--sl-gutter--minus));

--- a/source/assets/sass/components/_alerts.scss
+++ b/source/assets/sass/components/_alerts.scss
@@ -2,7 +2,7 @@
 @use '../config/color/brand';
 
 .sl-c-alert {
-  background: var(--sl-background--alert, var(--sl-color--highlight));
+  background: var(--sl-background--alert, black);
   color: var(--sl-color--white);
   font-size: var(--sl-font-size--small);
   padding-bottom: var(--sl-padding-block--alert, var(--sl-gutter--minus));
@@ -50,12 +50,6 @@
 
 .sl-c-alert--info {
   --sl-background--alert: var(--sl-color--midnight-blue);
-}
-
-.sl-c-alert--special {
-  --sl-align--alert: left;
-  --sl-background--alert: black;
-  --sl-padding-block--alert: var(--sl-gutter--triple);
 }
 
 .sl-c-alert-title {


### PR DESCRIPTION
Most of the text here is outdated at this point. The Sass core team
wants to keep the banner itself both for its political purpose and
because it's been pragmatically effective at getting racists to refuse
to use Sass.