### PR TITLE
Compile Sass for examples silently

### DIFF
--- a/source/helpers/components/codeExample.ts
+++ b/source/helpers/components/codeExample.ts
@@ -103,6 +103,7 @@ const generateCodeExample = (
     }
     const css = sass.compileString(sections[0], {
       syntax: syntax === 'sass' ? 'indented' : 'scss',
+      logger: sass.Logger.silent,
     }).css;
     if (css.trim()) {
       cssContents = css;


### PR DESCRIPTION
Examples often have `@debug` rules or intentionally show deprecated
behavior, so they tend to be noisy and crowd out more useful
compilation output for the site as a whole.