### PR TITLE
Replace the Unicode arrowheads with "➤"

### DIFF
--- a/source/_includes/compatibility.liquid
+++ b/source/_includes/compatibility.liquid
@@ -28,7 +28,7 @@
   {%- endif -%}
   {%- if details | strip -%}
     {%- # The no-op href here ensures that this toggle is focusable in browsers. -%}
-    <div><a href="javascript:;">▶</a></div>
+    <div><a href="javascript:;">➤</a></div>
   {%- endif -%}
 </dl>
 

--- a/source/assets/sass/components/_lists.scss
+++ b/source/assets/sass/components/_lists.scss
@@ -83,7 +83,7 @@
       li a {
         &.section {
           &::after {
-            content: '▶';
+            content: '➤';
             float: right;
             font-size: 0.5em;
             text-align: center;

--- a/source/documentation/index.md
+++ b/source/documentation/index.md
@@ -53,6 +53,6 @@ Implementations can also be marked as "partial":
 {% endcompatibility %}
 
 This indicates that the implementation only supports some aspects of the
-feature. These compatibility indicators (and many others) have a "▶" button,
+feature. These compatibility indicators (and many others) have a "➤" button,
 which can be clicked to show more details about exactly how the implementations
 differ and which versions support which aspects of the feature in question.

--- a/source/styleguide/components.md
+++ b/source/styleguide/components.md
@@ -13,7 +13,7 @@ title: Components
     <dt>Ruby Sass</dt>
     <dd>since 3.5.0</dd>
   </div>
-  <div><a href="#">▶︎</a></div>
+  <div><a href="#">➤︎</a></div>
 </dl>
 
 ## Open


### PR DESCRIPTION
The old character was being rendered as an emoji in some contexts,
which looked weird.