### PR TITLE
Remove a duplicate table of contents entry

### DIFF
--- a/source/_data/documentation.yml
+++ b/source/_data/documentation.yml
@@ -62,7 +62,6 @@ toc:
   - Breaking Changes: /documentation/breaking-changes/
     :children:
       - Strict Unary Operators: /documentation/breaking-changes/strict-unary/
-      - Random With Units: /documentation/breaking-changes/function-units/
       - Invalid Combinators: /documentation/breaking-changes/bogus-combinators/
       - Media Queries Level 4: /documentation/breaking-changes/media-logic/
       - <code>/</code> as Division: /documentation/breaking-changes/slash-div/


### PR DESCRIPTION
This is the same page that "Function Units" already links to.