### PR TITLE
Add the css-function-mixin deprecation in the menu

### DIFF
--- a/source/_data/documentation.yml
+++ b/source/_data/documentation.yml
@@ -74,6 +74,7 @@ toc:
       - Default Exports: /documentation/breaking-changes/default-export/
       - Null Alpha Channel: /documentation/breaking-changes/null-alpha/
       - abs() Percentage: /documentation/breaking-changes/abs-percent/
+      - Functions and Mixins Beginning with <code>--</code>: /documentation/breaking-changes/css-function-mixin/
   - Command Line: /documentation/cli/
     :children:
       - Dart Sass: /documentation/cli/dart-sass/

--- a/source/documentation/breaking-changes/index.md
+++ b/source/documentation/breaking-changes/index.md
@@ -22,6 +22,10 @@ time-sensitive, so they may be released with new minor version numbers instead.
 
 These breaking changes are coming soon or have recently been released:
 
+* [Functions and Mixins Beginning with `--` are
+  deprecated](/documentation/breaking-changes/abs-percent/) beginning in Dart
+  Sass 1.76.0.
+
 * [Passing a percentage unit to the global `abs()` is
   deprecated](/documentation/breaking-changes/abs-percent/) beginning in Dart
   Sass 1.65.0.


### PR DESCRIPTION
#1028 has forgotten to update those when adding the new deprecation