### PR TITLE
Include highlighted text in Playground URL state

### DIFF
--- a/source/assets/js/playground.ts
+++ b/source/assets/js/playground.ts
@@ -126,8 +126,6 @@ function setupPlayground() {
             y: 'center',
           }),
         });
-
-        editor.focus();
       } catch (err) {
         // (ignored)
       }

--- a/source/assets/js/playground.ts
+++ b/source/assets/js/playground.ts
@@ -8,17 +8,17 @@ import {compileString, info, Logger, OutputStyle, Syntax} from 'sass';
 import {displayForConsoleLog} from './playground/console-utils.js';
 import {editorSetup, outputSetup} from './playground/editor-setup.js';
 import {
-  base64ToState,
+  deserializeState,
   customLoader,
   logsToDiagnostics,
   ParseResult,
   PlaygroundState,
-  stateToBase64,
+  serializeState,
 } from './playground/utils.js';
 
 function setupPlayground() {
   const hash = location.hash.slice(1);
-  const hashState = base64ToState(hash);
+  const hashState = deserializeState(hash);
 
   const initialState: PlaygroundState = {
     inputFormat: hashState.inputFormat || 'scss',
@@ -237,7 +237,7 @@ function setupPlayground() {
   const debounceUpdateURL = debounce(updateURL, 200);
 
   function updateURL() {
-    const hash = stateToBase64(playgroundState);
+    const hash = serializeState(playgroundState);
     history.replaceState('playground', '', `#${hash}`);
   }
 

--- a/source/assets/js/playground.ts
+++ b/source/assets/js/playground.ts
@@ -114,7 +114,9 @@ function setupPlayground() {
           anchor: fromLine.from + fromC - 1,
           head: toLine.from + toC - 1,
         },
-        scrollIntoView: true,
+        effects: EditorView.scrollIntoView(fromLine.from, {
+          y: 'center',
+        }),
       });
 
       editor.focus();

--- a/source/assets/js/playground.ts
+++ b/source/assets/js/playground.ts
@@ -85,18 +85,13 @@ function setupPlayground() {
     | PlaygroundState['selection']
     | null {
     const sel = editor.state.selection;
-    if (sel.ranges.length !== 1) {
-      return null;
-    }
+    if (sel.ranges.length !== 1) return null;
 
     const range = sel.ranges[0];
-    if (range.empty) {
-      return null;
-    }
+    if (range.empty) return null;
 
     const fromLine = editor.state.doc.lineAt(range.from);
     const toLine = editor.state.doc.lineAt(range.to);
-
     return [
       fromLine.number,
       range.from - fromLine.from + 1,
@@ -105,10 +100,9 @@ function setupPlayground() {
     ];
   }
 
-  function restoreSelection() {
-    if (playgroundState.selection === null) {
-      return;
-    }
+  /** Updates the editor's selection based on `playgroundState.selection`. */
+  function restoreSelection(): void {
+    if (playgroundState.selection === null) return;
 
     try {
       const [fromL, fromC, toL, toC] = playgroundState.selection;

--- a/source/assets/js/playground/editor-setup.ts
+++ b/source/assets/js/playground/editor-setup.ts
@@ -30,6 +30,7 @@ import {
   highlightSpecialChars,
   keymap,
   lineNumbers,
+  drawSelection,
 } from '@codemirror/view';
 
 import {playgroundHighlightStyle} from './theme.js';
@@ -49,6 +50,7 @@ const editorSetup = (() => [
     closeBrackets(),
     autocompletion(),
     highlightActiveLine(),
+    drawSelection(),
     keymap.of([
       ...closeBracketsKeymap,
       ...defaultKeymap,

--- a/source/assets/js/playground/utils.ts
+++ b/source/assets/js/playground/utils.ts
@@ -14,6 +14,9 @@ export type PlaygroundState = {
   inputValue: string;
   compilerHasError: boolean;
   debugOutput: ConsoleLog[];
+
+  /** `[fromLine, fromColumn, toLine, toColumn]`; all 1-indexed.  */
+  selection: [number, number, number, number] | null;
 };
 
 export function serializeState(state: PlaygroundState): string {
@@ -38,7 +41,12 @@ function serializeStateContents(state: PlaygroundState): string {
 
 function serializeStateParams(state: PlaygroundState): string | null {
   const params = new URLSearchParams();
-  // TODO: serialize params
+
+  if (state.selection) {
+    const [fromL, fromC, toL, toC] = state.selection;
+    params.set('s', `L${fromL}C${fromC}-L${toL}C${toC}`);
+  }
+
   return params.size === 0 ? null : params.toString();
 }
 
@@ -100,7 +108,15 @@ function deserializeStateParams(
   input: string
 ): void {
   const params = new URLSearchParams(input);
-  // TODO: deserialize params
+
+  const s = params.has('s')
+    ? /^L(?<fromL>\d+)C(?<fromC>\d+)-L(?<toL>\d+)C(?<toC>\d+)$/i.exec(
+        params.get('s') as string
+      )?.groups
+    : null;
+  if (s) {
+    state.selection = [+s['fromL'], +s['fromC'], +s['toL'], +s['toC']];
+  }
 }
 
 type ParseResultSuccess = {css: string};

--- a/source/assets/js/playground/utils.ts
+++ b/source/assets/js/playground/utils.ts
@@ -15,7 +15,10 @@ export type PlaygroundState = {
   compilerHasError: boolean;
   debugOutput: ConsoleLog[];
 
-  /** `[fromLine, fromColumn, toLine, toColumn]`; all 1-indexed.  */
+  /**
+   * `[fromLine, fromColumn, toLine, toColumn]`; all 1-indexed. If this is null,
+   * the editor has no selection.
+   */
   selection: [number, number, number, number] | null;
 };
 
@@ -39,6 +42,10 @@ function serializeStateContents(state: PlaygroundState): string {
   return deflateToBase64(persistedState);
 }
 
+/**
+ * Serializes `state`'s non-boolean, non-textual parameters to a set of URL
+ * parameters that can be added to the URL hash.
+ */
 function serializeStateParams(state: PlaygroundState): string | null {
   const params = new URLSearchParams();
 
@@ -80,6 +87,10 @@ export function deserializeState(input: string): Partial<PlaygroundState> {
   return state;
 }
 
+/**
+ * Updates `state` with the result of deserializing `input`, which should be in
+ * the format produced by `serializeStateContents`.
+ */
 function deserializeStateContents(
   state: Partial<PlaygroundState>,
   input: string
@@ -103,6 +114,10 @@ function deserializeStateContents(
   state.inputValue = decoded.slice(2);
 }
 
+/**
+ * Updates `state` with the result of deserializing `input`, which should be in
+ * the format produced by `serializeStateParams`.
+ */
 function deserializeStateParams(
   state: Partial<PlaygroundState>,
   input: string

--- a/source/assets/js/playground/utils.ts
+++ b/source/assets/js/playground/utils.ts
@@ -17,7 +17,9 @@ export type PlaygroundState = {
 };
 
 export function serializeState(state: PlaygroundState): string {
-  return serializeStateContents(state);
+  const contents = serializeStateContents(state);
+  const params = serializeStateParams(state);
+  return `${contents}${params ? `?${params}` : ''}`;
 }
 
 /**
@@ -32,6 +34,12 @@ function serializeStateContents(state: PlaygroundState): string {
   const outputFormatChar = state.outputFormat === 'expanded' ? 1 : 0;
   const persistedState = `${inputFormatChar}${outputFormatChar}${state.inputValue}`;
   return deflateToBase64(persistedState);
+}
+
+function serializeStateParams(state: PlaygroundState): string | null {
+  const params = new URLSearchParams();
+  // TODO: serialize params
+  return params.size === 0 ? null : params.toString();
 }
 
 /** Compresses `input` and returns a base64 string of the compressed bytes. */
@@ -58,7 +66,9 @@ function inflateFromBase64(input: string): string {
 
 export function deserializeState(input: string): Partial<PlaygroundState> {
   const state: Partial<PlaygroundState> = {};
-  deserializeStateContents(state, input);
+  const [contents, query] = input.split('?');
+  if (contents) deserializeStateContents(state, contents);
+  if (query) deserializeStateParams(state, query);
   return state;
 }
 
@@ -83,6 +93,14 @@ function deserializeStateContents(
   state.inputFormat = decoded.charAt(0) === '1' ? 'scss' : 'indented';
   state.outputFormat = decoded.charAt(1) === '1' ? 'expanded' : 'compressed';
   state.inputValue = decoded.slice(2);
+}
+
+function deserializeStateParams(
+  state: Partial<PlaygroundState>,
+  input: string
+): void {
+  const params = new URLSearchParams(input);
+  // TODO: deserialize params
 }
 
 type ParseResultSuccess = {css: string};


### PR DESCRIPTION
Fixes #1090 😄🎉

Line numbers encoded as `L1C2-L3C4` instead of `1,2:3,4` because the former gets URI encoded verbatim, while the latter gets encoded as `1%2C2%3A3%2C4`.