### PR TITLE
Fix footer not showing the latest versions.

### DIFF
--- a/source/_data/releases.ts
+++ b/source/_data/releases.ts
@@ -106,7 +106,7 @@ async function getLatestVersion(repo: string): Promise<string> {
 /**
  * Returns the version and URL for the latest release of all implementations.
  */
-export default async function (): Promise<Record<string, Release>> {
+module.exports = async function (): Promise<Record<string, Release>> {
   const repos = ['sass/libsass', 'sass/dart-sass', 'sass/migrator'];
   const cache = await getCacheFile();
 
@@ -129,4 +129,4 @@ export default async function (): Promise<Record<string, Release>> {
   }
 
   return data;
-}
+};

--- a/source/_data/releases.ts
+++ b/source/_data/releases.ts
@@ -106,7 +106,7 @@ async function getLatestVersion(repo: string): Promise<string> {
 /**
  * Returns the version and URL for the latest release of all implementations.
  */
-// LiquidJS's `_data` directory loading mechanism specifically relies on the
+// Eleventy's `_data` directory loading mechanism specifically relies on the
 // CommonJS `module.exports` pattern to expose global variables. Using `export
 // default` is not recognized by this loader.
 module.exports = async function (): Promise<Record<string, Release>> {

--- a/source/_data/releases.ts
+++ b/source/_data/releases.ts
@@ -106,6 +106,9 @@ async function getLatestVersion(repo: string): Promise<string> {
 /**
  * Returns the version and URL for the latest release of all implementations.
  */
+// LiquidJS's `_data` directory loading mechanism specifically relies on the
+// CommonJS `module.exports` pattern to expose global variables. Using `export
+// default` is not recognized by this loader.
 module.exports = async function (): Promise<Record<string, Release>> {
   const repos = ['sass/libsass', 'sass/dart-sass', 'sass/migrator'];
   const cache = await getCacheFile();


### PR DESCRIPTION
Eleventy expects that default exports are provided with 'module.exports ='. Not with 'export default'.

Fixes #1176