### PR TITLE
[Playground] use CSS resize for sizing playground panels

### DIFF
--- a/source/assets/sass/components/_playground.scss
+++ b/source/assets/sass/components/_playground.scss
@@ -164,8 +164,8 @@ $playground-base-colors: (
   min-inline-size: 100%;
 
   @include config.sl-breakpoint--large {
-    min-inline-size: var(--sl-min-inline-size--playground-panel);
     max-inline-size: calc(100vw - var(--sl-min-inline-size--playground-panel));
+    min-inline-size: var(--sl-min-inline-size--playground-panel);
     resize: inline;
   }
 }
@@ -174,8 +174,8 @@ $playground-base-colors: (
   --sl-background--editor: var(--sl-color--code-background);
 
   @include config.sl-breakpoint--large {
-    resize: block;
     min-block-size: 2.5lh;
+    resize: block;
   }
 }
 

--- a/source/assets/sass/components/_playground.scss
+++ b/source/assets/sass/components/_playground.scss
@@ -131,8 +131,8 @@ $playground-base-colors: (
   @include config.sl-breakpoint--large {
     // magic numbers, the layout is well balanced with these proportions
     grid-template:
-      'sass css' minmax(20ex, 1fr)
-      'sass debug' minmax(0, 40%) / 1fr 1fr;
+      'sass css' auto
+      'sass debug' 1fr / auto 1fr;
     height: 100%;
     overflow: inherit;
   }
@@ -160,12 +160,23 @@ $playground-base-colors: (
 
 [data-code='source'] {
   --sl-background--editor: var(--sl-color--white);
-
   grid-area: sass;
+  min-inline-size: 100%;
+
+  @include config.sl-breakpoint--large {
+    min-inline-size: var(--sl-min-inline-size--playground-panel);
+    max-inline-size: calc(100vw - var(--sl-min-inline-size--playground-panel));
+    resize: inline;
+  }
 }
 
 [data-code='compiled'] {
   --sl-background--editor: var(--sl-color--code-background);
+
+  @include config.sl-breakpoint--large {
+    resize: block;
+    min-block-size: 2.5lh;
+  }
 }
 
 // Codemirror overrides
@@ -396,7 +407,11 @@ $playground-base-colors: (
 
 // Make sure all tab bar buttons and text get the same padding
 [data-tabbar~='item'] {
-  padding: var(--sl-gutter--half) var(--sl-gutter);
+  padding: var(--sl-gutter--half) var(--sl-padding-inline--tabbar-item, var(--sl-gutter));
+}
+
+.tabbar-title {
+  --sl-padding-inline--tabbar-item: var(--sl-gutter--half);
 }
 
 .sl-c-playground__tabbar-title {

--- a/source/assets/sass/config/_scale.scss
+++ b/source/assets/sass/config/_scale.scss
@@ -60,3 +60,4 @@ $sl-playground-heading: 2.75rem;
 $sl-line-height--console: 0.95;
 $sl-width--mac-stadium-icon: 7rem;
 $sl-width--twitter-link: 8rem;
+$sl-min-inline-size--playground-panel: 50ch;


### PR DESCRIPTION
Testing the difference between CSS resize and the SplitView web component in  https://github.com/sass/sass-site/pull/1204

This addresses number 4 in https://github.com/sass/sass-site/issues/779

TODO: 
- [ ] Allow block resize on smaller screen sizes
- [ ] Set max block size for compiled panel
- [ ] Set better default inline sizes

https://deploy-preview-1213--sass-lang.netlify.app/playground/
