### PR TITLE
Fix CodeMirror style loading bug

### DIFF
--- a/source/assets/js/playground.ts
+++ b/source/assets/js/playground.ts
@@ -85,6 +85,7 @@ function setupPlayground(): void {
   // Setup input Sass view
   const editor = new EditorView({
     doc: playgroundState.inputValue,
+    root: document,
     extensions: [
       ...editorSetup,
       EditorView.updateListener.of(v => {
@@ -106,6 +107,7 @@ function setupPlayground(): void {
 
   // Setup CSS view
   const viewer = new EditorView({
+    root: document,
     extensions: [...outputSetup],
     parent: document.querySelector('.sl-code-is-compiled') || undefined,
   });


### PR DESCRIPTION
In some instances, the CodeMirror styles were being added incorrectly, leading to the code editor not being laid out or styled.

<img width="1495" alt="image" src="https://github.com/user-attachments/assets/0c443dc7-b54e-4b0d-bcfb-df5351cb2829">


The bug appeared to be triggered by a race condition- if the SplitView web component loaded before CodeMirror, CodeMirror would attach styles to the SplitView's shadow root instead of the host Document. This explicitly sets the host Document as the place where styles should be attached.


