### PR TITLE
legacy-js-api page: Update Vite reference with Vite 6 having Modern API as default

### DIFF
--- a/source/documentation/breaking-changes/legacy-js-api.md
+++ b/source/documentation/breaking-changes/legacy-js-api.md
@@ -68,9 +68,9 @@ Webpack should already use the modern API by default, but if you're getting
 warnings, set `api` to `"modern"` or `"modern-compiler"`.
 See [Webpack's documentation] for more details.
 
-Vite still defaults to the legacy API, but you can similarly switch it by
-setting `api` to `"modern"` or `"modern-compiler"`. See [Vite's documentation]
-for more details.
+Vite 6 uses the modern API by default. Previous versions of Vite still use the
+legacy API, however from Vite 5.4 you can switch it by setting `api` to
+`"modern"` or `"modern-compiler"`. See [Vite's documentation] for more details.
 
 For other tools, check their documentation or issue tracker for information
 about supporting the modern Sass API.


### PR DESCRIPTION
With Vite 6 recently released, I was looking at the docs and noticed that we can update this description.
I'm not sure about the language so please feel free to suggest copy improvements. Thanks!

Reference: https://vite.dev/guide/migration.html#sass-now-uses-modern-api-by-default