### PR TITLE
Fix typos in `color.is-missing()` + "Breaking Changes" section

### DIFF
--- a/source/documentation/breaking-changes/color-4-api.md
+++ b/source/documentation/breaking-changes/color-4-api.md
@@ -68,6 +68,8 @@ warning when constructing a new [legacy color] or calling `color.change()` for a
 legacy color. In either case, if you pass a `space` parameter explicitly, you'll
 opt into the new behavior and `null` will be treated as a missing channel.
 
+[legacy color]: /documentation/values/colors#legacy-color-spaces
+
 ## Transition Period
 
 {% compatibility 'dart: "1.79.0"', 'libsass: false', 'ruby: false' %}{% endcompatibility %}

--- a/source/documentation/breaking-changes/function-units.md
+++ b/source/documentation/breaking-changes/function-units.md
@@ -202,8 +202,8 @@ will forbid any units.
 
 {% compatibility 'dart: "1.56.0"', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
 
-Currently, Sass emits a deprecation warning if you pass a `$weight` with no
-units or with units other than `%` to `color.mix()` or `color.invert()`.
+Currently, Sass emits a deprecation warning if you pass an index `$n` with units to
+`list.nth()` or `list.set-nth()`.
 
 ### Phase 2
 

--- a/source/documentation/breaking-changes/legacy-js-api.md
+++ b/source/documentation/breaking-changes/legacy-js-api.md
@@ -54,7 +54,7 @@ that contains a list of all Sass arguments, with asynchronous custom functions
 returning a promise.
 
 The modern API also uses a much more robust [`Value`] class that supports all
-Sass value stypes, type assertions, and easy map and list lookups.
+Sass values types, type assertions, and easy map and list lookups.
 
 [`Value`]: /documentation/js-api/classes/Value/
 

--- a/source/documentation/breaking-changes/legacy-js-api.md
+++ b/source/documentation/breaking-changes/legacy-js-api.md
@@ -54,7 +54,7 @@ that contains a list of all Sass arguments, with asynchronous custom functions
 returning a promise.
 
 The modern API also uses a much more robust [`Value`] class that supports all
-Sass values types, type assertions, and easy map and list lookups.
+Sass value types, type assertions, and easy map and list lookups.
 
 [`Value`]: /documentation/js-api/classes/Value/
 

--- a/source/documentation/modules/color.md
+++ b/source/documentation/modules/color.md
@@ -308,7 +308,7 @@ title: sass:color
 {% function 'color.is-legacy($color)', 'returns:boolean' %}
   {% compatibility 'dart: "1.79.0"', 'libsass: false', 'ruby: false', 'feature: "$space"' %}{% endcompatibility %}
 
-Returns whether `$color` is in a [legacy color space].
+  Returns whether `$color` is in a [legacy color space].
 
   [legacy color space]: /documentation/values/colors#legacy-color-spaces
 
@@ -330,7 +330,7 @@ Returns whether `$color` is in a [legacy color space].
 {% function 'color.is-missing($color, $channel)', 'returns:boolean' %}
   {% compatibility 'dart: "1.79.0"', 'libsass: false', 'ruby: false', 'feature: "$space"' %}{% endcompatibility %}
 
-Returns whether `$channel` is [missing] in `$color`. The `$channel` must be a
+  Returns whether `$channel` is [missing] in `$color`. The `$channel` must be a
   quoted string.
 
   [missing]: /documentation/values/colors#missing-channels
@@ -353,7 +353,7 @@ Returns whether `$channel` is [missing] in `$color`. The `$channel` must be a
 {% function 'color.is-powerless($color, $channel, $space: null)', 'returns:boolean' %}
   {% compatibility 'dart: "1.79.0"', 'libsass: false', 'ruby: false', 'feature: "$space"' %}{% endcompatibility %}
 
-Returns whether `$color`'s `$channel` is [powerless] in `$space`, which
+  Returns whether `$color`'s `$channel` is [powerless] in `$space`, which
   defaults to `$color`'s space. The `$channel` must be a quoted string and the
   `$space` must be an unquoted string.
 

--- a/source/documentation/modules/color.md
+++ b/source/documentation/modules/color.md
@@ -333,7 +333,7 @@ Returns whether `$color` is in a [legacy color space].
 Returns whether `$channel` is [missing] in `$color`. The `$channel` must be a
   quoted string.
 
-  [missing channel]: /documentation/values/colors#missing-channels
+  [missing]: /documentation/values/colors#missing-channels
 
   {% codeExample 'color-is-missing', false %}
     @use 'sass:color';


### PR DESCRIPTION
I tried to fix a few more errors with links that I found while reading the documentation. I'll check how they look within the test deploy.

|      Erroneous fragment      |        Fix        |
|:----------------------------:|-------------------|
|[[legacy color]][legacy-color]| [commit][commit-1]|
|[[missing]][is-missing]       | [commit][commit-2]|
|[value stypes][typo]          | [commit][commit-3]|
|[repetition][repeat]          | [commit][commit-4]|

I also discovered a repeating fragment and tried to rewrite it by analogy with the neighboring paragraphs. This definitely requires checking or adjusting according to the style you see as correct.

[legacy-color]: https://sass-lang.com/documentation/breaking-changes/color-4-api/#null-channel-values
[commit-1]: https://github.com/unennhexium/sass-site/commit/5f44133df69836d25cf9f6fd255539cad592090d
[is-missing]: https://sass-lang.com/documentation/modules/color/#is-missing
[commit-2]: https://github.com/unennhexium/sass-site/commit/6dc32afacd6d23d33dba3fff4904ce0e3e48bbaa
[typo]: https://sass-lang.com/documentation/breaking-changes/legacy-js-api/#custom-functions
[commit-3]: https://github.com/unennhexium/sass-site/commit/30b8b24bf8ea6d124c5da8dd127dc0083984e6f9
[repeat]: https://sass-lang.com/documentation/breaking-changes/function-units/#index
[commit-4]: https://github.com/unennhexium/sass-site/commit/64c0e551cd629c9cb9335b3a81a1cc0db89dc451