### PR TITLE
[Playground] Add background to gutter

### DIFF
--- a/source/assets/sass/components/_playground.scss
+++ b/source/assets/sass/components/_playground.scss
@@ -183,7 +183,7 @@ $playground-base-colors: (
   overflow-y: inherit;
 
   .cm-gutters {
-    background-color: transparent;
+    background-color: var(--sl-background--editor);
     border-right: none;
   }
 


### PR DESCRIPTION
Make the background of the editor gutter non-transparent again, which turns this:

![sass-lang com_playground_](https://github.com/user-attachments/assets/aaa07bbd-6c6d-4d90-a90d-2eb1404c1225)

into this (note the gutter on the left side of the editors):

![sass-lang com_playground_ (1)](https://github.com/user-attachments/assets/4155ec2a-d8af-4c7b-9e01-f989fdee6ecf)
