### PR TITLE
update example for --remove-prefix in sass-migrator

### DIFF
--- a/source/documentation/cli/migrator.md
+++ b/source/documentation/cli/migrator.md
@@ -319,7 +319,7 @@ $ cat style.scss
 }
 $ sass-migrator --migrate-deps module --remove-prefix=app- style.scss
 $ cat style.scss
-@import "theme";
+@use "theme";
 
 @mixin inverted {
   color: theme.$bg-color;


### PR DESCRIPTION
Output example below looks mistyped and I verified `@import` changed to `@use` by the command locally.
```
$ cat style.scss
@import "theme";

@mixin app-inverted {
  color: $app-bg-color;
  background-color: $app-color;
}
$ sass-migrator --migrate-deps module --remove-prefix=app- style.scss
$ cat style.scss
@import "theme";

@mixin inverted {
  color: theme.$bg-color;
  background-color: theme.$color;
}
```

But I'm not so familiar with migration command and maybe even sass. Feel free to correct me and reject it if I'm misunderstanding.

And, I'm sorry that I don't drink whisky as the contribution guide suggests.