### PR TITLE
Update the mixed decl examples to ones that actually warn

### DIFF
--- a/source/documentation/breaking-changes/mixed-decls.md
+++ b/source/documentation/breaking-changes/mixed-decls.md
@@ -15,7 +15,7 @@ duplicating the outer selector more than necessary. For example:
   .example {
     color: red;
 
-    a {
+    &--serious {
       font-weight: bold;
     }
 
@@ -25,7 +25,7 @@ duplicating the outer selector more than necessary. For example:
   .example
     color: red
 
-    a
+    &--serious
       font-weight: bold
 
 
@@ -36,7 +36,7 @@ duplicating the outer selector more than necessary. For example:
     font-weight: normal;
   }
 
-  .example a {
+  .example--serious {
     font-weight: bold;
   }
 {% endcodeExample %}
@@ -52,7 +52,7 @@ make the declarations apply in the order they appeared in the document, like so:
   .example {
     color: red;
 
-    a {
+    &--serious {
       font-weight: bold;
     }
 
@@ -62,7 +62,7 @@ make the declarations apply in the order they appeared in the document, like so:
   .example
     color: red
 
-    a
+    &--serious
       font-weight: bold
 
 
@@ -72,7 +72,7 @@ make the declarations apply in the order they appeared in the document, like so:
     color: red;
   }
 
-  .example a {
+  .example--serious {
     font-weight: bold;
   }
 
@@ -98,7 +98,7 @@ declarations in `& {}`:
   .example {
     color: red;
 
-    a {
+    &--serious {
       font-weight: bold;
     }
 
@@ -110,7 +110,7 @@ declarations in `& {}`:
   .example
     color: red
 
-    a
+    &--serious
       font-weight: bold
 
 


### PR DESCRIPTION
Since this page was first written, we made the mixed-decls check
smarter and now the example styesheets that are supposed to
demonstrate the warning don't produce a warning at all, because the
nested rules have different specificity.

Suggested by sass/dart-sass#2530