### PR TITLE
Document support/deprecations for new `attr()` function syntax

### DIFF
--- a/source/documentation/breaking-changes/attr-type.md
+++ b/source/documentation/breaking-changes/attr-type.md
@@ -1,0 +1,28 @@
+---
+title: 'Breaking Change: type() function'
+introduction: >
+  CSS has added a `type()` function with unique syntax. In order to support
+  flexible syntax for this function, user-defined functions named `type()` are
+  deprecated.
+---
+
+CSS Values and Units 5 defines [a `type()` function] for use in the `attr()`
+function. This function defines the syntax to use when parsing an HTML attribute
+as a CSS value, so for example `attr(data-count type(<number>))` would return
+the value of the `data-count` attribute as a CSS number. Although it's currently
+only defined in a working draft, Chrome already supports the `type()` function
+so Sass is adding support as well.
+
+[a `type()` function]: https://developer.mozilla.org/en-US/docs/Web/CSS/attr#attr-type
+
+Because the `type()` function doesn't follow the normal conventions for CSS
+expression syntax, Sass will need to parse it as a [special function] like
+`url()` or `element()`. Because this represents a breaking change for any
+existing Sass code that defined functions named `type()`, as of Sass 1.86.0 we
+are deprecating the ability to define functions with this name. Once this
+deprecation has been in place for at least three months, we'll release a version
+of Sass that parses `type()` as a special function instead.
+
+[special function]: /documentation/syntax/special-functions/
+
+{% render 'silencing_deprecations' %}

--- a/source/documentation/values/strings.md
+++ b/source/documentation/values/strings.md
@@ -205,6 +205,42 @@ code point, whether it's escaped or unescaped:
   @debug string.length(\7Fx)  // 5
 {% endcodeExample %}
 
+### Other Unquoted Strings
+
+In addition to identifiers, there are a few unusual corners of CSS syntax that
+are parsed as unquoted strings. These include:
+
+* [Special functions] like `url()` and `element()` whose arguments have
+  syntax that's different from normal CSS expression syntax.
+
+* [Unicode range] tokens like `U+0-7F` or `U+4??`.
+
+* [Hash tokens] whose values are identifiers but which aren't valid hex colors.
+
+* The value `%`. (This is only available when it's not directly between two other
+  values, because otherwise it would be ambiguous with [the modulo operator].)
+
+* The special value `!important`.
+
+[Special functions]: /documentation/syntax/special-functions/
+[Unicode range]: https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/unicode-range
+[Hash tokens]: https://www.w3.org/TR/css-syntax-3/#ref-for-typedef-hash-token%E2%91%A0
+[the modulo operator]: /documentation/operators/numeric/
+
+{% codeExample 'other-unquoted-strings', false %}
+  @debug url(https://example.org); // url(https://example.org)
+  @debug U+4??; // U+4??
+  @debug #my-background; // #my-background
+  @debug %; // %
+  @debug !important; // !important
+  ===
+  @debug url(https://example.org)  // url(https://example.org)
+  @debug U+4??  // U+4??
+  @debug #my-background  // #my-background
+  @debug %  // %
+  @debug !important  // !important
+{% endcodeExample %}
+
 ## String Indexes
 
 Sass has a number of [string functions][] that take or return numbers, called


### PR DESCRIPTION
See #1333