### PR TITLE
Update meta.md to include `mixins` as a return type of `meta.type-of`

### DIFF
--- a/source/documentation/modules/meta.md
+++ b/source/documentation/modules/meta.md
@@ -629,6 +629,7 @@ title: sass:meta
   * [`bool`](/documentation/values/booleans)
   * [`null`](/documentation/values/null)
   * [`function`](/documentation/values/functions)
+  * [`mixins`](/documentation/values/mixins)
   * [`arglist`](/documentation/values/lists#argument-lists)
 
   New possible values may be added in the future. It may return either `list` or


### PR DESCRIPTION
A very tiny change, but during development I spent a bit too long to figure out that  the `meta.type-of` of `meta.get-mixin(myMixin)` is not `function` but rather `mixin`. Makes a lot of sense, of course, but I didn't know it existed.

This PR makes the docs a bit more complete, I think.

Edit: I know you added the note `New possible values may be added in the future` in the docs. So if you feel that this list should not be extended explicitly, feel free to just close this :)