### PR TITLE
Make `mixins` label in list of return types for `meta.type-of` singular

### DIFF
--- a/source/documentation/modules/meta.md
+++ b/source/documentation/modules/meta.md
@@ -629,7 +629,7 @@ title: sass:meta
   * [`bool`](/documentation/values/booleans)
   * [`null`](/documentation/values/null)
   * [`function`](/documentation/values/functions)
-  * [`mixins`](/documentation/values/mixins)
+  * [`mixin`](/documentation/values/mixins)
   * [`arglist`](/documentation/values/lists#argument-lists)
 
   New possible values may be added in the future. It may return either `list` or


### PR DESCRIPTION
As mentioned in #1358, `mixins` in the list of return types for `meta.type-of` should be singular