### PR TITLE
[Style] Only give impl-status blocks negative margin after headers

### DIFF
--- a/source/assets/sass/components/_lists.scss
+++ b/source/assets/sass/components/_lists.scss
@@ -156,7 +156,10 @@
 
   &.impl-status {
     font-size: var(--sl-status-text-size);
-    margin-top: var(--sl-gutter--negative);
+
+    :is(h1, h2, h3, h4, h5, h6, .sl-c-introduction) + & {
+      margin-top: var(--sl-gutter--negative);
+    }
 
     dt {
       word-break: normal;


### PR DESCRIPTION
This helps avoid cases where they end up trying to wrap to the width
of earlier blocks, especially code examples.